### PR TITLE
Use friend property to hide impl function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ add_compile_options(-Wall -Wextra -Wpedantic -O3)
 find_package(yaml-cpp REQUIRED)
 find_package(OpenCV 4.5 REQUIRED)
 find_package(OpenVINO REQUIRED)
-find_package(Ceres REQUIRED)
+# find_package(Ceres REQUIRED)
 
 ## ROS2 相关依赖
 find_package(type_description_interfaces REQUIRED)

--- a/src/utility/rclcpp/visual/armor.hpp
+++ b/src/utility/rclcpp/visual/armor.hpp
@@ -7,6 +7,8 @@
 namespace rmcs::util::visual {
 
 struct Armor : public Movable {
+    friend Movable;
+
 public:
     struct Config {
         RclcppNode& rclcpp;
@@ -28,9 +30,9 @@ public:
 
     auto update() noexcept -> void;
 
+private:
     auto impl_move(const Translation&, const Orientation&) noexcept -> void;
 
-private:
     struct Impl;
     std::unique_ptr<Impl> pimpl;
 };

--- a/src/utility/rclcpp/visual/posture.hpp
+++ b/src/utility/rclcpp/visual/posture.hpp
@@ -6,6 +6,9 @@
 namespace rmcs::util::visual {
 
 struct Posture : Movable {
+    friend Movable;
+
+public:
     struct Config {
         RclcppNode& rclcpp;
 
@@ -20,9 +23,9 @@ struct Posture : Movable {
 
     auto update() noexcept -> void;
 
+private:
     auto impl_move(const Translation&, const Orientation&) noexcept -> void;
 
-private:
     struct Impl;
     std::unique_ptr<Impl> pimpl;
 };

--- a/src/utility/rclcpp/visual/transform.hpp
+++ b/src/utility/rclcpp/visual/transform.hpp
@@ -6,6 +6,9 @@
 namespace rmcs::util::visual {
 
 struct Transform : Movable {
+    friend Movable;
+
+public:
     struct Config {
         RclcppNode& rclcpp;
 
@@ -22,9 +25,9 @@ struct Transform : Movable {
 
     auto update() -> void;
 
+private:
     auto impl_move(const Translation&, const Orientation&) -> void;
 
-private:
     struct Impl;
     std::unique_ptr<Impl> pimpl;
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Pull Request 摘要

## 目的
使用友元属性隐藏CRTP实现函数，使基类 `Movable` 能够访问派生类的私有 `impl_move()` 方法。

## 主要变更

### CMakeLists.txt
- 注释掉 `find_package(Ceres REQUIRED)` 调用，禁用显式的Ceres依赖解析

### src/utility/rclcpp/visual/armor.hpp
- 在 `Armor` 结构体中添加 `friend Movable;` 声明
- 允许 `Movable` 基类访问 `Armor` 的私有成员，特别是 `impl_move()` 方法

### src/utility/rclcpp/visual/posture.hpp
- 在 `Posture` 结构体中添加 `friend Movable;` 声明
- 显式添加 `public:` 访问说明符，明确 `Config` 类型的公有地位
- `impl_move()` 保持私有，由友元声明提供访问权限

### src/utility/rclcpp/visual/transform.hpp
- 在 `Transform` 结构体中添加 `friend Movable;` 声明
- 显式添加 `public:` 访问说明符，明确 `Config` 嵌套结构体的公有地位
- `impl_move()` 保持私有，由友元声明提供访问权限

## 设计意图
通过友元声明，使得 `Movable` 基类能够调用派生类的私有 `impl_move()` 实现方法。这样用户只能通过基类公开的 `move()` 方法进行交互，而 `impl_move()` 作为实现细节保持隐藏和私有，符合CRTP设计模式的最佳实践。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->