### PR TITLE
fix(armor): correct armor count in EKFParameters

### DIFF
--- a/src/module/predictor/ekf_parameter.hpp
+++ b/src/module/predictor/ekf_parameter.hpp
@@ -57,11 +57,8 @@ struct EKFParameters {
     }
 
     static auto armor_num(DeviceId const& device) -> int {
-        auto is_balance = DeviceIds::kInfantry().contains(device);
-
         auto num = int {};
         if (device == DeviceId::OUTPOST || device == DeviceId::BASE) num = 3;
-        else if (is_balance) num = 2;
         else num = 4;
         return num;
     }


### PR DESCRIPTION
修正装甲板数目的逻辑，移除平衡步兵

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 修复装甲板数目逻辑

本 PR 修正了 `EKFParameters::armor_num()` 方法中的装甲板计数逻辑。

### 主要改动

在 `src/module/predictor/ekf_parameter.hpp` 文件中，简化了 `armor_num(DeviceId const&)` 方法的实现：

- **移除了对"平衡步兵"的特殊处理**：之前存在一个条件分支，当检测到"平衡步兵"设备类型时会返回装甲板数为 2，现已删除此逻辑
- **删除了本地变量 `is_balance`** 及其关联的条件判断分支
- **统一了非哨兵/非基地设备的装甲板数**：所有不是 `OUTPOST` 或 `BASE` 的设备现在都统一返回装甲板数为 4

### 当前实现

```cpp
static auto armor_num(DeviceId const& device) -> int {
    auto num = int {};
    if (device == DeviceId::OUTPOST || device == DeviceId::BASE) num = 3;
    else num = 4;
    return num;
}
```

装甲板计数规则现为：
- 哨兵 (OUTPOST)：3 块
- 基地 (BASE)：3 块  
- 其他设备：4 块

### 影响范围

代码改动仅涉及 EKF 参数配置文件，未有公共接口签名变化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->