### PR TITLE
Feat/feishu history

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -96,6 +96,6 @@ fire_control:
 
 visualization:
   framerate: 60
-  monitor_host: "192.168.2.154"
+  monitor_host: "127.0.0.1"
   monitor_port: "5000"
   stream_type: "RTP_JEPG"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -6,7 +6,7 @@ capturer:
   show_loss_framerate: false
   show_loss_framerate_interval: 500
   reconnect_wait_interval: 100
-  enable_trigger_sync: false
+  enable_trigger_sync: true
   # hikcamera or local_video
   source: "hikcamera"
   hikcamera:
@@ -22,7 +22,7 @@ capturer:
     invert_image: false
     software_sync: false
     trigger_mode: false
-    fixed_framerate: false
+    fixed_framerate: true
   local_video:
     # 替换为你具体的路径
     location: "/workspaces/alliance/test_videos/outpost.mp4"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -6,6 +6,7 @@ capturer:
   show_loss_framerate: false
   show_loss_framerate_interval: 500
   reconnect_wait_interval: 100
+  enable_trigger_sync: false
   # hikcamera or local_video
   source: "hikcamera"
   hikcamera:
@@ -95,6 +96,6 @@ fire_control:
 
 visualization:
   framerate: 60
-  monitor_host: "127.0.0.1"
+  monitor_host: "192.168.2.154"
   monitor_port: "5000"
   stream_type: "RTP_JEPG"

--- a/src/component.cpp
+++ b/src/component.cpp
@@ -1,6 +1,7 @@
 #include "kernel/feishu.hpp"
 #include "module/debug/action_throttler.hpp"
 #include "module/debug/framerate.hpp"
+#include "utility/clock.hpp"
 #include "utility/rclcpp/node.hpp"
 #include "utility/rclcpp/visual/transform.hpp"
 #include "utility/shared/context.hpp"
@@ -15,13 +16,17 @@ namespace rmcs {
 
 using namespace rmcs::util;
 using namespace kernel;
+using Clock = util::Clock;
 
 class AutoAimComponent final : public rmcs_executor::Component {
 public:
     explicit AutoAimComponent() noexcept
         : rclcpp { get_component_name() } {
 
+        register_input("/predefined/timestamp", predefined_timestamp_);
         register_input("/tf", rmcs_tf);
+        register_input("/camera/trigger/seq", camera_trigger_seq_);
+        register_input("/camera/trigger/timestamp", camera_trigger_timestamp_);
 
         register_output("/gimbal/auto_aim/auto_aim_enabled", gimbal_takeover, false);
         register_output(
@@ -41,6 +46,8 @@ public:
 
         action_throttler.register_action("tf_not_ready");
         action_throttler.register_action("commit_control_state_failed");
+        action_throttler.register_action("commit_camera_trigger_failed");
+        action_throttler.register_action("camera_trigger_gap_detected");
     }
 
     auto update() -> void override {
@@ -56,7 +63,11 @@ public:
 private:
     static constexpr auto auto_aim_state_timeout { std::chrono::milliseconds { 100 } };
 
+    InputInterface<Clock::time_point> predefined_timestamp_;
     InputInterface<rmcs_description::Tf> rmcs_tf;
+
+    InputInterface<std::uint64_t> camera_trigger_seq_;
+    InputInterface<Clock::time_point> camera_trigger_timestamp_;
 
     double current_gimbal_yaw { std::numeric_limits<double>::quiet_NaN() };
     double current_gimbal_pitch { std::numeric_limits<double>::quiet_NaN() };
@@ -65,9 +76,11 @@ private:
     std::unique_ptr<visual::Transform> visual_odom_to_camera;
 
     Feishu<RuntimeRole::Control> feishu;
+    Channel<CameraTriggerEvent> camera_trigger_channel;
     ControlState control_state;
     AutoAimState auto_aim_state;
     bool auto_aim_state_received_ { false };
+    std::uint64_t last_committed_camera_trigger_seq_ { 0 };
 
     OutputInterface<bool> gimbal_takeover;
     OutputInterface<bool> shoot_permitted;
@@ -133,6 +146,7 @@ private:
     auto publish_control_state() -> void {
         update_gimbal_direction();
         update_control_state();
+        publish_camera_trigger_event();
 
         auto success = feishu.commit(control_state);
         if (!success) {
@@ -143,8 +157,38 @@ private:
         }
     }
 
+    auto publish_camera_trigger_event() -> void {
+        auto trigger_seq = *camera_trigger_seq_;
+        if (trigger_seq == 0 || trigger_seq == last_committed_camera_trigger_seq_) {
+            return;
+        }
+
+        if (last_committed_camera_trigger_seq_ != 0
+            && trigger_seq > last_committed_camera_trigger_seq_ + 1) {
+            action_throttler.dispatch("camera_trigger_gap_detected", [&] {
+                rclcpp.warn("Camera trigger gap detected: last={}, current={}",
+                    last_committed_camera_trigger_seq_, trigger_seq);
+            });
+        } else {
+            action_throttler.reset("camera_trigger_gap_detected");
+        }
+
+        auto success = camera_trigger_channel.commit(CameraTriggerEvent {
+            .seq       = trigger_seq,
+            .timestamp = *camera_trigger_timestamp_,
+        });
+        if (!success) {
+            action_throttler.dispatch("commit_camera_trigger_failed",
+                [&] { rclcpp.info("commit camera trigger event failed!"); });
+            return;
+        }
+
+        last_committed_camera_trigger_seq_ = trigger_seq;
+        action_throttler.reset("commit_camera_trigger_failed");
+    }
+
     auto update_control_state() -> void {
-        control_state.timestamp = Clock::now();
+        control_state.timestamp = *predefined_timestamp_;
 
         auto odom_to_camera_transform =
             fast_tf::lookup_transform<rmcs_description::OdomImu, rmcs_description::CameraLink>(

--- a/src/kernel/capturer.cpp
+++ b/src/kernel/capturer.cpp
@@ -1,4 +1,5 @@
 #include "capturer.hpp"
+#include "kernel/feishu.hpp"
 #include "module/capturer/common.hpp"
 #include "module/capturer/hikcamera.hpp"
 #include "module/capturer/local_video.hpp"
@@ -23,9 +24,13 @@ struct Capturer::Impl {
     FramerateCounter loss_image_framerate {};
 
     std::chrono::milliseconds reconnect_wait_interval { 500 };
+    std::chrono::milliseconds trigger_sync_max_age { 50 };
 
     util::spsc_queue<Image*, 10> capture_queue;
     std::jthread runtime_thread;
+    Channel<util::CameraTriggerEvent> camera_trigger_channel;
+    bool enable_trigger_sync { false };
+    std::uint64_t last_bound_trigger_seq_ { 0 };
 
     auto initialize(const YAML::Node& yaml) noexcept -> Result try {
         auto source = yaml["source"].as<std::string>();
@@ -60,6 +65,9 @@ struct Capturer::Impl {
         if (!instantitation_result.has_value()) {
             return std::unexpected { instantitation_result.error() };
         }
+
+        auto trigger_sync_config = yaml["enable_trigger_sync"].as<bool>();
+        enable_trigger_sync      = (source == "hikcamera" && trigger_sync_config);
 
         auto show_loss_framerate          = yaml["show_loss_framerate"].as<bool>();
         auto show_loss_framerate_interval = yaml["show_loss_framerate_interval"].as<int>();
@@ -97,7 +105,37 @@ struct Capturer::Impl {
         log.info("[Capturer runtime thread] starts");
 
         // Success context
+        auto missing_trigger_limit  = util::TimesLimit { 3 };
+        auto bind_trigger_timestamp = [&](std::unique_ptr<Image>& image) {
+            if (!enable_trigger_sync) {
+                return;
+            }
+
+            auto capture_timestamp = image->get_timestamp();
+            if (auto trigger = camera_trigger_channel.fetch_latest_matching(
+                    [&](const util::CameraTriggerEvent& candidate) {
+                        return candidate.seq > last_bound_trigger_seq_
+                            && candidate.timestamp <= capture_timestamp
+                            && capture_timestamp - candidate.timestamp <= trigger_sync_max_age;
+                    })) {
+                image->set_timestamp(trigger->timestamp);
+                last_bound_trigger_seq_ = trigger->seq;
+                missing_trigger_limit.reset();
+                missing_trigger_limit.enable();
+                return;
+            }
+
+            if (missing_trigger_limit.tick()) {
+                log.warn("No camera trigger event is available for the captured image");
+            } else if (missing_trigger_limit.enabled()) {
+                missing_trigger_limit.disable();
+                log.warn(
+                    "{} times, stop printing trigger-sync warnings", missing_trigger_limit.count);
+            }
+        };
+
         auto success_callback = [&](std::unique_ptr<Image> image) {
+            bind_trigger_timestamp(image);
             auto newest = image.release();
             if (!capture_queue.push(newest)) {
 

--- a/src/kernel/feishu.hpp
+++ b/src/kernel/feishu.hpp
@@ -3,7 +3,6 @@
 #include "utility/shared/context.hpp"
 #include "utility/shared/interprocess.hpp"
 #include <optional>
-#include <tuple>
 #include <type_traits>
 #include <utility>
 
@@ -48,66 +47,34 @@ struct ChannelTraits<util::CameraTriggerEvent> {
         kCameraTriggerHistoryCapacity>::Recv;
 };
 
-namespace detail {
-
-    template <typename Client, typename T>
-    auto channel_write(Client& client, const T& data) noexcept -> bool {
-        if constexpr (requires { client.push(data); }) {
-            return client.push(data);
-        } else {
-            client.with_write([&](T& shared) { shared = data; });
-            return true;
-        }
-    }
-
-    template <typename Client, typename T>
-    auto channel_read_latest(Client& client, T& buffer) noexcept -> bool {
-        if constexpr (requires { client.latest(buffer); }) {
-            return client.latest(buffer);
-        } else {
-            client.with_read([&](const T& shared) { buffer = shared; });
-            return true;
-        }
-    }
-
-    template <typename Client, typename Predicate, typename T>
-    auto channel_read_latest_matching(Client& client, Predicate&& predicate, T& buffer) noexcept
-        -> bool {
-        if constexpr (requires {
-                          client.find_latest(std::forward<Predicate>(predicate), buffer);
-                      }) {
-            return client.find_latest(std::forward<Predicate>(predicate), buffer);
-        } else {
-            return false;
-        }
-    }
-
-    template <typename Client, typename T>
-    auto channel_pop_next(Client& client, T& buffer) noexcept -> bool {
-        if constexpr (requires { client.pop_next(buffer); }) {
-            return client.pop_next(buffer);
-        } else {
-            return false;
-        }
-    }
-
-} // namespace detail
-
 template <typename T>
 class Channel {
 public:
+    static_assert(shm_name<T> != nullptr, "Channel<T> requires shm_name<T> specialization");
+
     using SendClient = typename ChannelTraits<T>::SendClient;
     using RecvClient = typename ChannelTraits<T>::RecvClient;
 
     auto commit(const T& data) noexcept -> bool {
         if (!ensure_open(send_client_, shm_name<T>)) [[unlikely]]
             return false;
-        return detail::channel_write(send_client_, data);
+
+        if constexpr (requires { send_client_.push(data); }) {
+            return send_client_.push(data);
+        } else {
+            send_client_.with_write([&](T& shared) { shared = data; });
+            return true;
+        }
     }
 
     auto fetch() noexcept -> const T& {
         if (!ensure_open(recv_client_, shm_name<T>)) return recv_buffer_;
-        std::ignore = detail::channel_read_latest(recv_client_, recv_buffer_);
+
+        if constexpr (requires { recv_client_.latest(recv_buffer_); }) {
+            recv_client_.latest(recv_buffer_);
+        } else {
+            recv_client_.with_read([&](const T& shared) { recv_buffer_ = shared; });
+        }
         return recv_buffer_;
     }
 
@@ -122,23 +89,16 @@ public:
         }
 
         auto buffer = T {};
-        if (!detail::channel_read_latest_matching(
-                recv_client_, std::forward<Predicate>(predicate), buffer)) {
-            return std::nullopt;
-        }
-        recv_buffer_ = buffer;
-        return buffer;
-    }
-
-    auto pop_next() noexcept -> std::optional<T> {
-        if (!ensure_open(recv_client_, shm_name<T>)) {
+        if constexpr (requires {
+                          recv_client_.find_latest(std::forward<Predicate>(predicate), buffer);
+                      }) {
+            if (!recv_client_.find_latest(std::forward<Predicate>(predicate), buffer)) {
+                return std::nullopt;
+            }
+        } else {
             return std::nullopt;
         }
 
-        auto buffer = T {};
-        if (!detail::channel_pop_next(recv_client_, buffer)) {
-            return std::nullopt;
-        }
         recv_buffer_ = buffer;
         return buffer;
     }
@@ -157,6 +117,9 @@ private:
 template <RuntimeRole Role>
 class Feishu {
 public:
+    static_assert(Role == RuntimeRole::AutoAim || Role == RuntimeRole::Control,
+        "Feishu<Role> only supports AutoAim and Control");
+
     using AutoAimState = util::AutoAimState;
     using ControlState = util::ControlState;
 

--- a/src/kernel/feishu.hpp
+++ b/src/kernel/feishu.hpp
@@ -2,11 +2,18 @@
 
 #include "utility/shared/context.hpp"
 #include "utility/shared/interprocess.hpp"
+#include <optional>
+#include <tuple>
+#include <type_traits>
+#include <utility>
 
 namespace rmcs::kernel {
 
 template <typename T>
 constexpr const char* shm_name = nullptr;
+
+inline constexpr std::size_t kControlStateHistoryCapacity  = 4096;
+inline constexpr std::size_t kCameraTriggerHistoryCapacity = 512;
 
 template <>
 constexpr auto shm_name<util::AutoAimState> = "/shm_autoaim_state";
@@ -14,7 +21,138 @@ constexpr auto shm_name<util::AutoAimState> = "/shm_autoaim_state";
 template <>
 constexpr auto shm_name<util::ControlState> = "/shm_control_state";
 
+template <>
+constexpr auto shm_name<util::CameraTriggerEvent> = "/shm_camera_trigger";
+
 enum class RuntimeRole { AutoAim, Control };
+
+template <typename T>
+struct ChannelTraits {
+    using SendClient = typename rmcs::shm::Client<T>::Send;
+    using RecvClient = typename rmcs::shm::Client<T>::Recv;
+};
+
+template <>
+struct ChannelTraits<util::ControlState> {
+    using SendClient =
+        typename rmcs::shm::HistoryClient<util::ControlState, kControlStateHistoryCapacity>::Send;
+    using RecvClient =
+        typename rmcs::shm::HistoryClient<util::ControlState, kControlStateHistoryCapacity>::Recv;
+};
+
+template <>
+struct ChannelTraits<util::CameraTriggerEvent> {
+    using SendClient = typename rmcs::shm::HistoryClient<util::CameraTriggerEvent,
+        kCameraTriggerHistoryCapacity>::Send;
+    using RecvClient = typename rmcs::shm::HistoryClient<util::CameraTriggerEvent,
+        kCameraTriggerHistoryCapacity>::Recv;
+};
+
+namespace detail {
+
+    template <typename Client, typename T>
+    auto channel_write(Client& client, const T& data) noexcept -> bool {
+        if constexpr (requires { client.push(data); }) {
+            return client.push(data);
+        } else {
+            client.with_write([&](T& shared) { shared = data; });
+            return true;
+        }
+    }
+
+    template <typename Client, typename T>
+    auto channel_read_latest(Client& client, T& buffer) noexcept -> bool {
+        if constexpr (requires { client.latest(buffer); }) {
+            return client.latest(buffer);
+        } else {
+            client.with_read([&](const T& shared) { buffer = shared; });
+            return true;
+        }
+    }
+
+    template <typename Client, typename Predicate, typename T>
+    auto channel_read_latest_matching(Client& client, Predicate&& predicate, T& buffer) noexcept
+        -> bool {
+        if constexpr (requires {
+                          client.find_latest(std::forward<Predicate>(predicate), buffer);
+                      }) {
+            return client.find_latest(std::forward<Predicate>(predicate), buffer);
+        } else {
+            return false;
+        }
+    }
+
+    template <typename Client, typename T>
+    auto channel_pop_next(Client& client, T& buffer) noexcept -> bool {
+        if constexpr (requires { client.pop_next(buffer); }) {
+            return client.pop_next(buffer);
+        } else {
+            return false;
+        }
+    }
+
+} // namespace detail
+
+template <typename T>
+class Channel {
+public:
+    using SendClient = typename ChannelTraits<T>::SendClient;
+    using RecvClient = typename ChannelTraits<T>::RecvClient;
+
+    auto commit(const T& data) noexcept -> bool {
+        if (!ensure_open(send_client_, shm_name<T>)) [[unlikely]]
+            return false;
+        return detail::channel_write(send_client_, data);
+    }
+
+    auto fetch() noexcept -> const T& {
+        if (!ensure_open(recv_client_, shm_name<T>)) return recv_buffer_;
+        std::ignore = detail::channel_read_latest(recv_client_, recv_buffer_);
+        return recv_buffer_;
+    }
+
+    auto updated() noexcept -> bool {
+        return ensure_open(recv_client_, shm_name<T>) && recv_client_.is_updated();
+    }
+
+    template <typename Predicate>
+    auto fetch_latest_matching(Predicate&& predicate) noexcept -> std::optional<T> {
+        if (!ensure_open(recv_client_, shm_name<T>)) {
+            return std::nullopt;
+        }
+
+        auto buffer = T {};
+        if (!detail::channel_read_latest_matching(
+                recv_client_, std::forward<Predicate>(predicate), buffer)) {
+            return std::nullopt;
+        }
+        recv_buffer_ = buffer;
+        return buffer;
+    }
+
+    auto pop_next() noexcept -> std::optional<T> {
+        if (!ensure_open(recv_client_, shm_name<T>)) {
+            return std::nullopt;
+        }
+
+        auto buffer = T {};
+        if (!detail::channel_pop_next(recv_client_, buffer)) {
+            return std::nullopt;
+        }
+        recv_buffer_ = buffer;
+        return buffer;
+    }
+
+private:
+    template <typename Client>
+    static auto ensure_open(Client& client, const char* name) noexcept -> bool {
+        return client.opened() || (name && client.open(name));
+    }
+
+    SendClient send_client_ {};
+    RecvClient recv_client_ {};
+    T recv_buffer_ {};
+};
 
 template <RuntimeRole Role>
 class Feishu {
@@ -25,37 +163,22 @@ public:
     using SendData = std::conditional_t<Role == RuntimeRole::AutoAim, AutoAimState, ControlState>;
     using RecvData = std::conditional_t<Role == RuntimeRole::AutoAim, ControlState, AutoAimState>;
 
-    using SendClient = rmcs::shm::Client<SendData>::Send;
-    using RecvClient = rmcs::shm::Client<RecvData>::Recv;
+    auto commit(SendData const& data) noexcept -> bool { return send_channel_.commit(data); }
 
-    auto commit(SendData const& data) noexcept -> bool {
-        if (!ensure_open(send_client, shm_name<SendData>)) [[unlikely]]
-            return false;
-        send_client.with_write([&](SendData& shared) { shared = data; });
-        return true;
-    }
+    auto fetch() noexcept -> const RecvData& { return recv_channel_.fetch(); }
 
-    auto fetch() noexcept -> const RecvData& {
-        // Note:直接读取当前共享内存中的数据；如需检测是否有新数据，请先调用 updated()
-        if (!ensure_open(recv_client, shm_name<RecvData>)) return recv_buffer;
-        recv_client.with_read([&](RecvData const& shared) { recv_buffer = shared; });
-        return recv_buffer;
-    }
+    auto updated() noexcept -> bool { return recv_channel_.updated(); }
 
-    auto updated() noexcept -> bool {
-        return ensure_open(recv_client, shm_name<RecvData>) && recv_client.is_updated();
+    template <RuntimeRole R = Role>
+    auto fetch_latest_before(util::Clock::time_point timestamp) noexcept
+        -> std::enable_if_t<R == RuntimeRole::AutoAim, std::optional<ControlState>> {
+        return recv_channel_.fetch_latest_matching(
+            [&](const ControlState& state) { return state.timestamp <= timestamp; });
     }
 
 private:
-    SendClient send_client {};
-    RecvClient recv_client {};
-
-    RecvData recv_buffer {};
-
-    template <typename Client>
-    auto ensure_open(Client& client, const char* name) noexcept -> bool {
-        return client.opened() || (name && client.open(name));
-    }
+    Channel<SendData> send_channel_ {};
+    Channel<RecvData> recv_channel_ {};
 };
 
-}
+} // namespace rmcs::kernel

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -14,8 +14,8 @@
 #include "utility/rclcpp/parameters.hpp"
 #include "utility/singleton/running.hpp"
 
-#include <csignal>
 #include <experimental/scope>
+#include <rclcpp/utilities.hpp>
 #include <string>
 #include <string_view>
 #include <yaml-cpp/yaml.h>
@@ -27,10 +27,10 @@ using namespace rmcs::kernel;
 auto main() -> int {
     using namespace std::chrono_literals;
 
-    std::signal(SIGINT, [](int) { util::set_running(false); });
-
     auto rclcpp_node = util::RclcppNode { "AutoAim" };
     rclcpp_node.set_pub_topic_prefix("/rmcs/auto_aim/");
+
+    rclcpp::on_shutdown([] { util::set_running(false); });
 
     {
         /// Runtime
@@ -112,18 +112,20 @@ auto main() -> int {
         ///
         /// Steps
         ///
-        const auto fetch_control_state = [&] -> ControlState {
+        const auto fetch_control_state = [&](Clock::time_point image_timestamp) -> ControlState {
             if (is_local_runtime) {
                 auto state = ControlState {};
                 state.reset();
                 return state;
             }
-            if (!feishu.updated()) {
-                action_throttler.dispatch(control_state_label,
-                    [&] { rclcpp_node.warn("Control state 尚未更新，使用上一次缓存值."); });
-            } else {
+
+            if (auto state = feishu.fetch_latest_before(image_timestamp)) {
                 action_throttler.reset(control_state_label);
+                return *state;
             }
+
+            action_throttler.dispatch(control_state_label,
+                [&] { rclcpp_node.warn("Control state history 不可用，使用当前最新缓存值."); });
             return feishu.fetch();
         };
 
@@ -141,7 +143,7 @@ auto main() -> int {
         };
 
         for (;;) {
-            if (!util::get_running()) [[unlikely]]
+            if (!util::get_running() || !rclcpp::ok()) [[unlikely]]
                 break;
 
             rclcpp_node.spin_once();
@@ -154,7 +156,7 @@ auto main() -> int {
                 } };
                 std::ignore = stream_guard;
 
-                auto control_state = fetch_control_state();
+                auto control_state = fetch_control_state(image->get_timestamp());
                 auto next_state    = AutoAimState {};
                 next_state.reset();
 

--- a/src/utility/shared/context.hpp
+++ b/src/utility/shared/context.hpp
@@ -4,6 +4,7 @@
 #include "utility/math/linear.hpp"
 #include "utility/robot/id.hpp"
 #include <cmath>
+#include <cstdint>
 #include <limits>
 
 namespace rmcs::util {
@@ -69,6 +70,12 @@ struct AutoAimState {
     }
 };
 static_assert(std::is_trivially_copyable_v<AutoAimState>);
+
+struct CameraTriggerEvent {
+    std::uint64_t seq {};
+    Clock::time_point timestamp {};
+};
+static_assert(std::is_trivially_copyable_v<CameraTriggerEvent>);
 
 struct ControlState {
     Clock::time_point timestamp {};

--- a/src/utility/shared/interprocess.hpp
+++ b/src/utility/shared/interprocess.hpp
@@ -1,8 +1,8 @@
 #pragma once
 #include <array>
 #include <atomic>
-#include <cstddef>
 #include <concepts>
+#include <cstddef>
 #include <cstdint>
 #include <fcntl.h>
 #include <sys/mman.h>
@@ -10,6 +10,65 @@
 #include <unistd.h>
 
 namespace rmcs::shm {
+
+namespace detail {
+
+    template <typename Context, std::size_t Len>
+    class MappedContext final {
+    public:
+        MappedContext()                                        = default;
+        MappedContext(const MappedContext&)                    = delete;
+        auto operator=(const MappedContext&) -> MappedContext& = delete;
+
+        ~MappedContext() noexcept {
+            if (context_ != nullptr) {
+                munmap(static_cast<void*>(context_), Len);
+            }
+            if (shm_fd_ != -1) {
+                close(shm_fd_);
+            }
+        }
+
+        auto open_sender(const char* id) noexcept -> bool {
+            return open(id, O_CREAT | O_RDWR, true);
+        }
+
+        auto open_receiver(const char* id) noexcept -> bool { return open(id, O_RDWR, false); }
+
+        auto opened() const noexcept -> bool { return context_ != nullptr; }
+
+        auto get() const noexcept -> Context* { return context_; }
+
+    private:
+        auto open(const char* id, int flags, bool resize) noexcept -> bool {
+            if (opened()) return true;
+
+            auto fd = shm_open(id, flags, 0666);
+            if (fd == -1) {
+                return false;
+            }
+
+            if (resize && ftruncate(fd, Len) == -1) {
+                close(fd);
+                return false;
+            }
+
+            auto* shm_ptr = mmap(nullptr, Len, PROT_WRITE | PROT_READ, MAP_SHARED, fd, 0);
+            if (shm_ptr == MAP_FAILED) {
+                close(fd);
+                return false;
+            }
+
+            shm_fd_  = fd;
+            context_ = static_cast<Context*>(shm_ptr);
+            return true;
+        }
+
+        int shm_fd_ { -1 };
+        Context* context_ { nullptr };
+    };
+
+} // namespace detail
 
 template <typename T>
 struct alignas(64) SharedContext final {
@@ -26,50 +85,24 @@ struct Client {
     using Context = SharedContext<T>;
 
     static constexpr auto kContextLen = sizeof(Context);
-    static constexpr auto kDataLen    = sizeof(T);
 
     class Send final {
     public:
-        ~Send() noexcept {
-            if (context) {
-                munmap(static_cast<void*>(context), kContextLen);
-            }
-            if (shm_fd != -1) {
-                close(shm_fd);
-            }
-        }
-        auto open(const char* id) noexcept -> bool {
-            shm_fd = shm_open(id, O_CREAT | O_RDWR, 0666);
-            if (shm_fd == -1) {
-                return false;
-            }
-            if (ftruncate(shm_fd, kContextLen) == -1) {
-                close(shm_fd);
-                return false;
-            }
+        Send()                               = default;
+        Send(const Send&)                    = delete;
+        auto operator=(const Send&) -> Send& = delete;
 
-            auto* shm_ptr =
-                mmap(nullptr, kContextLen, PROT_WRITE | PROT_READ, MAP_SHARED, shm_fd, 0);
-            if (shm_ptr == MAP_FAILED) {
-                close(shm_fd);
-                return false;
-            }
-
-            context = static_cast<Context*>(shm_ptr);
-            return true;
-        }
-        auto opened() const noexcept { return context != nullptr; }
+        auto open(const char* id) noexcept -> bool { return context_.open_sender(id); }
+        auto opened() const noexcept { return context_.opened(); }
         auto send(const T& data) noexcept -> void {
-            if (!context) return;
-            context->version.fetch_add(1, std::memory_order::acq_rel);
-            context->data = data;
-            context->version.fetch_add(1, std::memory_order::acq_rel);
+            with_write([&](T& shared) { shared = data; });
         }
 
         template <typename F>
         auto with_write(F&& fn) noexcept -> void
             requires std::invocable<F, T&>
         {
+            auto* context = context_.get();
             if (!context) return;
 
             context->version.fetch_add(1, std::memory_order::acq_rel);
@@ -78,57 +111,26 @@ struct Client {
         }
 
     private:
-        int shm_fd { -1 };
-        Context* context { nullptr };
+        detail::MappedContext<Context, kContextLen> context_ {};
     };
 
     class Recv {
     public:
-        ~Recv() noexcept {
-            if (context) {
-                munmap(static_cast<void*>(context), kContextLen);
-            }
-            if (shm_fd != -1) {
-                close(shm_fd);
-            }
-        }
+        Recv()                               = default;
+        Recv(const Recv&)                    = delete;
+        auto operator=(const Recv&) -> Recv& = delete;
 
-        auto open(const char* id) noexcept -> bool {
-            shm_fd = shm_open(id, O_RDWR, 0666);
-            if (shm_fd == -1) {
-                return false;
-            }
-
-            auto* shm_ptr =
-                mmap(nullptr, kContextLen, PROT_READ | PROT_WRITE, MAP_SHARED, shm_fd, 0);
-            if (shm_ptr == MAP_FAILED) {
-                close(shm_fd);
-                return false;
-            }
-
-            context = static_cast<Context*>(shm_ptr);
-            return true;
-        }
-        auto opened() const noexcept { return context != nullptr; }
+        auto open(const char* id) noexcept -> bool { return context_.open_receiver(id); }
+        auto opened() const noexcept { return context_.opened(); }
         auto recv(T& out_data) const noexcept -> void {
-            if (!context) return;
-
-            auto version1 = std::uint64_t {};
-            auto version2 = std::uint64_t {};
-
-            do {
-                version1 = context->version.load(std::memory_order::acquire);
-                out_data = context->data;
-                version2 = context->version.load(std::memory_order::acquire);
-            } while ((version1 != version2) || (version1 & 1));
-
-            version = version2;
+            with_read([&](const T& shared) { out_data = shared; });
         }
 
         template <typename F>
         auto with_read(F&& fn) const noexcept -> void
             requires std::invocable<F, const T&>
         {
+            auto* context = context_.get();
             if (!context) return;
 
             auto snapshot = T {};
@@ -146,6 +148,7 @@ struct Client {
         }
 
         auto is_updated() const noexcept -> bool {
+            auto* context = context_.get();
             if (!context) return false;
 
             auto current = context->version.load(std::memory_order::acquire);
@@ -155,8 +158,7 @@ struct Client {
     private:
         mutable std::uint64_t version { 0 };
 
-        int shm_fd { -1 };
-        Context* context { nullptr };
+        detail::MappedContext<Context, kContextLen> context_ {};
     };
 };
 
@@ -180,40 +182,24 @@ struct HistoryClient {
 
     class Send final {
     public:
-        ~Send() noexcept {
-            if (context) {
-                munmap(static_cast<void*>(context), kContextLen);
-            }
-            if (shm_fd != -1) {
-                close(shm_fd);
-            }
-        }
+        Send()                               = default;
+        Send(const Send&)                    = delete;
+        auto operator=(const Send&) -> Send& = delete;
 
         auto open(const char* id) noexcept -> bool {
-            shm_fd = shm_open(id, O_CREAT | O_RDWR, 0666);
-            if (shm_fd == -1) {
-                return false;
-            }
-            if (ftruncate(shm_fd, kContextLen) == -1) {
-                close(shm_fd);
+            if (!context_.open_sender(id)) {
                 return false;
             }
 
-            auto* shm_ptr =
-                mmap(nullptr, kContextLen, PROT_WRITE | PROT_READ, MAP_SHARED, shm_fd, 0);
-            if (shm_ptr == MAP_FAILED) {
-                close(shm_fd);
-                return false;
-            }
-
-            context       = static_cast<Context*>(shm_ptr);
+            auto* context = context_.get();
             next_sequence = context->committed.load(std::memory_order::acquire);
             return true;
         }
 
-        auto opened() const noexcept { return context != nullptr; }
+        auto opened() const noexcept { return context_.opened(); }
 
         auto push(const T& data) noexcept -> bool {
+            auto* context = context_.get();
             if (!context) return false;
 
             const auto sequence = next_sequence++;
@@ -229,45 +215,32 @@ struct HistoryClient {
         }
 
     private:
-        int shm_fd { -1 };
-        Context* context { nullptr };
+        detail::MappedContext<Context, kContextLen> context_ {};
         std::uint64_t next_sequence { 0 };
     };
 
     class Recv final {
     public:
-        ~Recv() noexcept {
-            if (context) {
-                munmap(static_cast<void*>(context), kContextLen);
-            }
-            if (shm_fd != -1) {
-                close(shm_fd);
-            }
-        }
+        Recv()                               = default;
+        Recv(const Recv&)                    = delete;
+        auto operator=(const Recv&) -> Recv& = delete;
 
         auto open(const char* id) noexcept -> bool {
-            shm_fd = shm_open(id, O_RDWR, 0666);
-            if (shm_fd == -1) {
+            if (!context_.open_receiver(id)) {
                 return false;
             }
 
-            auto* shm_ptr =
-                mmap(nullptr, kContextLen, PROT_READ | PROT_WRITE, MAP_SHARED, shm_fd, 0);
-            if (shm_ptr == MAP_FAILED) {
-                close(shm_fd);
-                return false;
-            }
-
-            context               = static_cast<Context*>(shm_ptr);
+            auto* context         = context_.get();
             const auto committed  = context->committed.load(std::memory_order::acquire);
             observed_committed    = 0;
             next_sequence_to_pop_ = committed;
             return true;
         }
 
-        auto opened() const noexcept { return context != nullptr; }
+        auto opened() const noexcept { return context_.opened(); }
 
         auto is_updated() const noexcept -> bool {
+            auto* context = context_.get();
             if (!context) return false;
             return context->committed.load(std::memory_order::acquire) != observed_committed;
         }
@@ -278,6 +251,7 @@ struct HistoryClient {
 
         template <typename Predicate>
         auto find_latest(Predicate&& predicate, T& out_data) const noexcept -> bool {
+            auto* context = context_.get();
             if (!context) return false;
 
             const auto committed = context->committed.load(std::memory_order::acquire);
@@ -289,8 +263,8 @@ struct HistoryClient {
                     continue;
                 }
                 if (predicate(candidate)) {
-                    out_data            = candidate;
-                    observed_committed  = committed;
+                    out_data           = candidate;
+                    observed_committed = committed;
                     return true;
                 }
             }
@@ -300,6 +274,7 @@ struct HistoryClient {
         }
 
         auto pop_next(T& out_data) const noexcept -> bool {
+            auto* context = context_.get();
             if (!context) return false;
 
             const auto committed = context->committed.load(std::memory_order::acquire);
@@ -331,14 +306,15 @@ struct HistoryClient {
         }
 
         auto read_sequence(std::uint64_t sequence, T& out_data) const noexcept -> bool {
+            auto* context = context_.get();
             if (!context) return false;
 
             const auto& entry = context->entries[sequence % N];
 
-            auto version1         = std::uint64_t {};
-            auto version2         = std::uint64_t {};
-            auto stored_sequence  = std::uint64_t {};
-            auto candidate        = T {};
+            auto version1        = std::uint64_t {};
+            auto version2        = std::uint64_t {};
+            auto stored_sequence = std::uint64_t {};
+            auto candidate       = T {};
 
             do {
                 version1        = entry.version.load(std::memory_order::acquire);
@@ -358,8 +334,7 @@ struct HistoryClient {
         mutable std::uint64_t observed_committed { 0 };
         mutable std::uint64_t next_sequence_to_pop_ { 0 };
 
-        int shm_fd { -1 };
-        Context* context { nullptr };
+        detail::MappedContext<Context, kContextLen> context_ {};
     };
 };
 

--- a/src/utility/shared/interprocess.hpp
+++ b/src/utility/shared/interprocess.hpp
@@ -1,8 +1,13 @@
 #pragma once
+#include <array>
 #include <atomic>
+#include <cstddef>
 #include <concepts>
+#include <cstdint>
 #include <fcntl.h>
 #include <sys/mman.h>
+#include <type_traits>
+#include <unistd.h>
 
 namespace rmcs::shm {
 
@@ -155,4 +160,207 @@ struct Client {
     };
 };
 
-}
+template <typename T, std::size_t N>
+struct HistoryClient {
+    static_assert(N > 0, "History capacity must be non-zero");
+    static_assert(std::is_trivially_copyable_v<T>, "T must be trivially copyable");
+
+    struct alignas(64) Entry final {
+        alignas(64) std::atomic<std::uint64_t> version;
+        std::uint64_t sequence;
+        T data;
+    };
+
+    struct alignas(64) Context final {
+        alignas(64) std::atomic<std::uint64_t> committed;
+        alignas(64) std::array<Entry, N> entries;
+    };
+
+    static constexpr auto kContextLen = sizeof(Context);
+
+    class Send final {
+    public:
+        ~Send() noexcept {
+            if (context) {
+                munmap(static_cast<void*>(context), kContextLen);
+            }
+            if (shm_fd != -1) {
+                close(shm_fd);
+            }
+        }
+
+        auto open(const char* id) noexcept -> bool {
+            shm_fd = shm_open(id, O_CREAT | O_RDWR, 0666);
+            if (shm_fd == -1) {
+                return false;
+            }
+            if (ftruncate(shm_fd, kContextLen) == -1) {
+                close(shm_fd);
+                return false;
+            }
+
+            auto* shm_ptr =
+                mmap(nullptr, kContextLen, PROT_WRITE | PROT_READ, MAP_SHARED, shm_fd, 0);
+            if (shm_ptr == MAP_FAILED) {
+                close(shm_fd);
+                return false;
+            }
+
+            context       = static_cast<Context*>(shm_ptr);
+            next_sequence = context->committed.load(std::memory_order::acquire);
+            return true;
+        }
+
+        auto opened() const noexcept { return context != nullptr; }
+
+        auto push(const T& data) noexcept -> bool {
+            if (!context) return false;
+
+            const auto sequence = next_sequence++;
+            auto& entry         = context->entries[sequence % N];
+
+            entry.version.fetch_add(1, std::memory_order::acq_rel);
+            entry.sequence = sequence;
+            entry.data     = data;
+            entry.version.fetch_add(1, std::memory_order::acq_rel);
+
+            context->committed.store(next_sequence, std::memory_order::release);
+            return true;
+        }
+
+    private:
+        int shm_fd { -1 };
+        Context* context { nullptr };
+        std::uint64_t next_sequence { 0 };
+    };
+
+    class Recv final {
+    public:
+        ~Recv() noexcept {
+            if (context) {
+                munmap(static_cast<void*>(context), kContextLen);
+            }
+            if (shm_fd != -1) {
+                close(shm_fd);
+            }
+        }
+
+        auto open(const char* id) noexcept -> bool {
+            shm_fd = shm_open(id, O_RDWR, 0666);
+            if (shm_fd == -1) {
+                return false;
+            }
+
+            auto* shm_ptr =
+                mmap(nullptr, kContextLen, PROT_READ | PROT_WRITE, MAP_SHARED, shm_fd, 0);
+            if (shm_ptr == MAP_FAILED) {
+                close(shm_fd);
+                return false;
+            }
+
+            context               = static_cast<Context*>(shm_ptr);
+            const auto committed  = context->committed.load(std::memory_order::acquire);
+            observed_committed    = 0;
+            next_sequence_to_pop_ = committed;
+            return true;
+        }
+
+        auto opened() const noexcept { return context != nullptr; }
+
+        auto is_updated() const noexcept -> bool {
+            if (!context) return false;
+            return context->committed.load(std::memory_order::acquire) != observed_committed;
+        }
+
+        auto latest(T& out_data) const noexcept -> bool {
+            return find_latest([](const T&) { return true; }, out_data);
+        }
+
+        template <typename Predicate>
+        auto find_latest(Predicate&& predicate, T& out_data) const noexcept -> bool {
+            if (!context) return false;
+
+            const auto committed = context->committed.load(std::memory_order::acquire);
+            const auto oldest    = oldest_sequence(committed);
+
+            for (auto sequence = committed; sequence > oldest; --sequence) {
+                auto candidate = T {};
+                if (!read_sequence(sequence - 1, candidate)) {
+                    continue;
+                }
+                if (predicate(candidate)) {
+                    out_data            = candidate;
+                    observed_committed  = committed;
+                    return true;
+                }
+            }
+
+            observed_committed = committed;
+            return false;
+        }
+
+        auto pop_next(T& out_data) const noexcept -> bool {
+            if (!context) return false;
+
+            const auto committed = context->committed.load(std::memory_order::acquire);
+            const auto oldest    = oldest_sequence(committed);
+
+            if (next_sequence_to_pop_ < oldest) {
+                next_sequence_to_pop_ = oldest;
+                observed_committed    = committed;
+                return false;
+            }
+
+            if (next_sequence_to_pop_ >= committed) {
+                observed_committed = committed;
+                return false;
+            }
+
+            if (!read_sequence(next_sequence_to_pop_, out_data)) {
+                return false;
+            }
+
+            ++next_sequence_to_pop_;
+            observed_committed = committed;
+            return true;
+        }
+
+    private:
+        static auto oldest_sequence(std::uint64_t committed) noexcept -> std::uint64_t {
+            return committed > N ? committed - N : 0;
+        }
+
+        auto read_sequence(std::uint64_t sequence, T& out_data) const noexcept -> bool {
+            if (!context) return false;
+
+            const auto& entry = context->entries[sequence % N];
+
+            auto version1         = std::uint64_t {};
+            auto version2         = std::uint64_t {};
+            auto stored_sequence  = std::uint64_t {};
+            auto candidate        = T {};
+
+            do {
+                version1        = entry.version.load(std::memory_order::acquire);
+                stored_sequence = entry.sequence;
+                candidate       = entry.data;
+                version2        = entry.version.load(std::memory_order::acquire);
+            } while ((version1 != version2) || (version1 & 1));
+
+            if (stored_sequence != sequence) {
+                return false;
+            }
+
+            out_data = candidate;
+            return true;
+        }
+
+        mutable std::uint64_t observed_committed { 0 };
+        mutable std::uint64_t next_sequence_to_pop_ { 0 };
+
+        int shm_fd { -1 };
+        Context* context { nullptr };
+    };
+};
+
+} // namespace rmcs::shm

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -121,6 +121,12 @@ ament_add_gtest(
     ${TEST_DIR}/feishu_test.cpp
 )
 
+# Timestamp alignment
+ament_add_gtest(
+    test_timestamp_alignment
+    ${TEST_DIR}/timestamp_alignment.cpp
+)
+
 # Action throttler
 ament_add_gtest(
     test_action_throttler

--- a/test/timestamp_alignment.cpp
+++ b/test/timestamp_alignment.cpp
@@ -1,0 +1,157 @@
+#include <gtest/gtest.h>
+
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <string>
+#include <sys/mman.h>
+#include <type_traits>
+#include <unistd.h>
+
+#include "kernel/feishu.hpp"
+#include "utility/shared/interprocess.hpp"
+
+namespace {
+
+using namespace std::chrono_literals;
+
+using rmcs::kernel::Feishu;
+using rmcs::kernel::RuntimeRole;
+using rmcs::shm::HistoryClient;
+using rmcs::util::CameraTriggerEvent;
+using rmcs::util::Clock;
+using rmcs::util::ControlState;
+
+struct ShmScope {
+    explicit ShmScope(std::string name)
+        : name_(std::move(name)) {
+        (void)::shm_unlink(name_.c_str());
+    }
+
+    ~ShmScope() { (void)::shm_unlink(name_.c_str()); }
+
+    [[nodiscard]] auto c_str() const noexcept -> const char* { return name_.c_str(); }
+
+private:
+    std::string name_;
+};
+
+struct FeishuShmScope {
+    FeishuShmScope() {
+        for (auto name : kNames) {
+            (void)::shm_unlink(name);
+        }
+    }
+
+    ~FeishuShmScope() {
+        for (auto name : kNames) {
+            (void)::shm_unlink(name);
+        }
+    }
+
+private:
+    static constexpr std::array kNames {
+        rmcs::kernel::shm_name<rmcs::util::AutoAimState>,
+        rmcs::kernel::shm_name<rmcs::util::ControlState>,
+        rmcs::kernel::shm_name<rmcs::util::CameraTriggerEvent>,
+    };
+};
+
+auto unique_shm_name(const char* prefix) -> std::string {
+    static auto counter = std::atomic<std::uint64_t> { 0 };
+    return std::string { "/" } + prefix + "_" + std::to_string(::getpid()) + "_"
+        + std::to_string(counter.fetch_add(1, std::memory_order_relaxed));
+}
+
+auto make_control_state(Clock::time_point timestamp) -> ControlState {
+    auto state      = ControlState {};
+    state.timestamp = timestamp;
+    return state;
+}
+
+TEST(TimestampAlignment, ClockDomainUsesSteadyClock) {
+    EXPECT_TRUE((std::is_same_v<Clock, std::chrono::steady_clock>));
+}
+
+TEST(TimestampAlignment, HistoryClientPopNextConsumesCameraTriggersInOrder) {
+    using Channel = HistoryClient<CameraTriggerEvent, 8>;
+
+    auto shm_name = ShmScope { unique_shm_name("rmcs_auto_aim_trigger_fifo") };
+    auto send     = Channel::Send {};
+    auto recv     = Channel::Recv {};
+
+    ASSERT_TRUE(send.open(shm_name.c_str()));
+    ASSERT_TRUE(recv.open(shm_name.c_str()));
+
+    auto base = Clock::now();
+    ASSERT_TRUE(send.push(CameraTriggerEvent { .seq = 11, .timestamp = base + 1ms }));
+    ASSERT_TRUE(send.push(CameraTriggerEvent { .seq = 12, .timestamp = base + 2ms }));
+    ASSERT_TRUE(send.push(CameraTriggerEvent { .seq = 13, .timestamp = base + 3ms }));
+
+    auto event = CameraTriggerEvent {};
+    ASSERT_TRUE(recv.pop_next(event));
+    EXPECT_EQ(event.seq, 11U);
+    EXPECT_EQ(event.timestamp, base + 1ms);
+
+    ASSERT_TRUE(recv.pop_next(event));
+    EXPECT_EQ(event.seq, 12U);
+    EXPECT_EQ(event.timestamp, base + 2ms);
+
+    ASSERT_TRUE(recv.pop_next(event));
+    EXPECT_EQ(event.seq, 13U);
+    EXPECT_EQ(event.timestamp, base + 3ms);
+
+    EXPECT_FALSE(recv.pop_next(event));
+}
+
+TEST(TimestampAlignment, HistoryClientFindLatestChoosesNewestStateNotAfterImageTimestamp) {
+    using Channel = HistoryClient<ControlState, 8>;
+
+    auto shm_name = ShmScope { unique_shm_name("rmcs_auto_aim_control_history") };
+    auto send     = Channel::Send {};
+    auto recv     = Channel::Recv {};
+
+    ASSERT_TRUE(send.open(shm_name.c_str()));
+    ASSERT_TRUE(recv.open(shm_name.c_str()));
+
+    auto base = Clock::now();
+    ASSERT_TRUE(send.push(make_control_state(base + 10ms)));
+    ASSERT_TRUE(send.push(make_control_state(base + 20ms)));
+    ASSERT_TRUE(send.push(make_control_state(base + 30ms)));
+
+    auto matched = ControlState {};
+    ASSERT_TRUE(recv.find_latest(
+        [&](const ControlState& state) { return state.timestamp <= base + 25ms; }, matched));
+    EXPECT_EQ(matched.timestamp, base + 20ms);
+
+    ASSERT_TRUE(recv.find_latest(
+        [&](const ControlState& state) { return state.timestamp <= base + 10ms; }, matched));
+    EXPECT_EQ(matched.timestamp, base + 10ms);
+
+    EXPECT_FALSE(
+        recv.find_latest([&](const ControlState& state) { return state.timestamp < base; }, matched));
+}
+
+TEST(TimestampAlignment, FeishuFetchLatestBeforeUsesControlStateHistorySemantics) {
+    auto shm_scope = FeishuShmScope {};
+    auto control   = Feishu<RuntimeRole::Control> {};
+    auto auto_aim  = Feishu<RuntimeRole::AutoAim> {};
+
+    auto base = Clock::now();
+    ASSERT_TRUE(control.commit(make_control_state(base + 10ms)));
+    ASSERT_TRUE(control.commit(make_control_state(base + 20ms)));
+    ASSERT_TRUE(control.commit(make_control_state(base + 30ms)));
+
+    auto matched = auto_aim.fetch_latest_before(base + 25ms);
+    ASSERT_TRUE(matched.has_value());
+    EXPECT_EQ(matched->timestamp, base + 20ms);
+
+    matched = auto_aim.fetch_latest_before(base + 30ms);
+    ASSERT_TRUE(matched.has_value());
+    EXPECT_EQ(matched->timestamp, base + 30ms);
+
+    EXPECT_FALSE(auto_aim.fetch_latest_before(base + 5ms).has_value());
+}
+
+} // namespace


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Feishu历史记录和相机触发事件同步功能

本PR在系统中引入了共享内存历史记录机制和相机触发事件同步功能，用于实现精确的时间戳对齐和状态历史访问。

## 核心功能变更

### 共享内存基础设施增强
- 在 `src/utility/shared/interprocess.hpp` 中引入了 `MappedContext` RAII包装器，集中管理共享内存的映射生命周期
- 实现了新的 `HistoryClient<T, N>` 模板类，提供环形缓冲区的共享内存通道，支持：
  - `Send::push()` - 写入数据到下一个序列号槽位
  - `Recv::latest()` - 读取最新数据
  - `Recv::find_latest(Predicate)` - 按条件查找最新匹配的历史数据
  - `Recv::pop_next()` - 按FIFO顺序读取数据

### Feishu通信层重构
- 在 `src/kernel/feishu.hpp` 中添加了通用的 `Channel<T>` 包装类，支持对不同数据类型的一致处理
- 引入了 `ChannelTraits` 模板，用于映射数据类型到相应的共享内存客户端
- 新增 `Feishu::fetch_latest_before(Clock::time_point)` 方法，返回指定时刻之前的历史控制状态

### 相机触发事件系统
- 定义了新的 `CameraTriggerEvent` 结构体，包含单调递增的序列号和时间戳
- 在 `src/component.cpp` 中实现了相机触发事件的发布和提交流程，包括：
  - 触发间隙检测和日志记录
  - 触发序列号的连续性验证
  - 提交失败时的限流日志

### Capturer触发同步支持
- 在 `src/kernel/capturer.cpp` 中添加了 `bind_trigger_timestamp` 逻辑
- 当启用触发同步时，自动从相机触发事件历史中查找与当前帧时间戳匹配的触发事件
- 实现了缺失触发事件的有界警告机制

### 运行时集成
- 更新了 `src/runtime.cpp` 的ROS2关闭处理，从信号处理改为ROS2的`on_shutdown`回调
- 修改 `fetch_control_state` 以接收图像时间戳，通过 `fetch_latest_before` 获取历史控制状态
- 改进了控制状态不可用时的警告机制

### 配置更新
- 在 `config/config.yaml` 中添加 `enable_trigger_sync` 开关
- 更改 `hikcamera` 的 `fixed_framerate` 为 `true`

## 测试支持
- 添加了 `test/timestamp_alignment.cpp` 测试套件，验证：
  - Clock类型为 `std::chrono::steady_clock`
  - HistoryClient的FIFO顺序和查询语义
  - Feishu的历史状态检索行为

## 代码更改统计
- 总行数变更：+435/-112
- 涉及文件8个
- 主要影响模块：共享内存通信、组件控制、相机采集、系统运行时

<!-- end of auto-generated comment: release notes by coderabbit.ai -->