### PR TITLE
feat: refine visualization granularity with multi-layered debug control

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -107,7 +107,14 @@ fire_control:
 
 visualization:
   framerate: 60
+  # e.g. monitor_host: "192.168.3.125"
   monitor_host: "127.0.0.1"
-  # monitor_host: "192.168.3.125"
   monitor_port: "5000"
   stream_type: "RTP_JEPG"
+
+  image_enabled: true
+  visible_armors_enabled: true
+  visible_robot_enabled: true
+  camera_pose_enabled: true
+  aiming_direction_enabled: true
+  mpc_plan_enabled: true

--- a/src/kernel/visualization.cpp
+++ b/src/kernel/visualization.cpp
@@ -33,17 +33,30 @@ struct Visualization::Impl {
         util::string_t monitor_port = "5000";
         util::string_t stream_type  = "RTP_JEPG";
 
+        bool image_enabled            = true;
+        bool visible_armors_enabled   = true;
+        bool visible_robot_enabled    = true;
+        bool camera_pose_enabled      = true;
+        bool aiming_direction_enabled = true;
+        bool mpc_plan_enabled         = true;
+
         static constexpr auto metas = std::tuple {
-            &Config::framerate,
-            "framerate",
-            &Config::monitor_host,
-            "monitor_host",
-            &Config::monitor_port,
-            "monitor_port",
-            &Config::stream_type,
-            "stream_type",
+            // clang-format off
+            &Config::framerate,               "framerate",
+            &Config::monitor_host,            "monitor_host",
+            &Config::monitor_port,            "monitor_port",
+            &Config::stream_type,             "stream_type",
+            &Config::image_enabled,           "image_enabled",
+            &Config::visible_armors_enabled,  "visible_armors_enabled",
+            &Config::visible_robot_enabled,   "visible_robot_enabled",
+            &Config::camera_pose_enabled,     "camera_pose_enabled",
+            &Config::aiming_direction_enabled,"aiming_direction_enabled",
+            &Config::mpc_plan_enabled,        "mpc_plan_enabled",
+            // clang-format on
         };
     };
+
+    Config config {};
 
     Printer log { "visual" };
 
@@ -68,7 +81,6 @@ struct Visualization::Impl {
     }
 
     auto initialize(const YAML::Node& yaml, RclcppNode& visual_node) noexcept -> NormalResult {
-        auto config = Config { };
         auto result = config.serialize(yaml);
         if (!result.has_value()) {
             return std::unexpected { result.error() };
@@ -103,13 +115,14 @@ struct Visualization::Impl {
         });
 
         is_initialized = true;
-        return { };
+        return {};
     }
 
     auto initialized() const noexcept { return is_initialized; }
 
     auto send_image(const Image& image) noexcept -> bool {
         if (!is_initialized) return false;
+        if (!config.image_enabled) return false;
 
         const auto& mat = image.details().mat;
 
@@ -150,16 +163,19 @@ struct Visualization::Impl {
 
     auto update_visible_armors(std::span<Armor3D const> armors) const -> bool {
         if (!is_initialized) return false;
+        if (!config.visible_armors_enabled) return false;
         return armors_detect->visualize(armors, "visible_armors", kOdomLink);
     }
 
     auto update_visible_robot(std::span<Armor3D const> armors) const -> bool {
         if (!is_initialized) return false;
+        if (!config.visible_robot_enabled) return false;
         return armors_group->visualize(armors, "visible_robot", kOdomLink);
     }
 
     auto update_aiming_direction(double yaw, double pitch) const -> void {
         if (!is_initialized) return;
+        if (!config.aiming_direction_enabled) return;
         aiming_direction->move(Translation::kZero(), euler_to_quaternion(yaw, pitch, 0.0));
         aiming_direction->update();
     }
@@ -167,12 +183,14 @@ struct Visualization::Impl {
     auto update_mpc_plan(double yaw, double pitch, double yaw_rate, double pitch_rate,
         double yaw_acc, double pitch_acc) const -> void {
         if (!is_initialized) return;
+        if (!config.mpc_plan_enabled) return;
         mpc_plan->publish_planned_yaw(yaw, yaw_rate, yaw_acc);
         mpc_plan->publish_planned_pitch(pitch, pitch_rate, pitch_acc);
     }
 
     auto update_camera_pose(const Orientation& orientation) const -> void {
         if (!is_initialized) return;
+        if (!config.camera_pose_enabled) return;
         camera_transform->move(Translation::kZero(), orientation);
         camera_transform->update();
     }

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -192,10 +192,8 @@ auto main() -> int {
                 command.robot_center      = Translation { result->center_position };
 
                 visualization.update_aiming_direction(command.yaw, command.pitch);
-                if (command.feedforward_valid) {
-                    visualization.update_mpc_plan(command.yaw, command.pitch, command.yaw_rate,
-                        command.pitch_rate, command.yaw_acc, command.pitch_acc);
-                }
+                visualization.update_mpc_plan(command.yaw, command.pitch, command.yaw_rate,
+                    command.pitch_rate, command.yaw_acc, command.pitch_acc);
             }
         }
 

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -172,7 +172,10 @@ auto main() -> int {
         auto target  = tracker.decide(armors_3d, image->get_timestamp());
         auto command = AutoAimState::kInvalid();
         if (target.allow_control && target.snapshot) {
-            auto& snapshot     = target.snapshot;
+            auto& snapshot = target.snapshot;
+            auto armors    = snapshot->predicted_armors(Clock::now());
+            visualization.update_visible_robot(armors);
+
             const auto control = target.tracking_confirmed;
             const auto yaw     = context.yaw;
             if (auto result = fire_control.solve(*snapshot, control, yaw)) {
@@ -187,11 +190,13 @@ auto main() -> int {
                 command.pitch_acc         = result->pitch_acc;
                 command.feedforward_valid = result->feedforward_valid;
                 command.robot_center      = Translation { result->center_position };
+
+                visualization.update_aiming_direction(command.yaw, command.pitch);
+                if (command.feedforward_valid) {
+                    visualization.update_mpc_plan(command.yaw, command.pitch, command.yaw_rate,
+                        command.pitch_rate, command.yaw_acc, command.pitch_acc);
+                }
             }
-            auto armors = snapshot->predicted_armors(Clock::now());
-            visualization.update_visible_robot(armors);
-            visualization.update_mpc_plan(command.yaw, command.pitch, command.yaw_rate,
-                command.pitch_rate, command.yaw_acc, command.pitch_acc);
         }
 
         /// 4. Transmit State


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## PR 摘要：完善可视化函数的多层级调试控制

### 概述
本PR通过引入细粒度的可视化配置控制，增强了调试可视化功能的灵活性。用户现在可以通过配置文件独立启用或禁用各项可视化功能，包括图像发送、装甲识别、机器人预测、相机位置、瞄准方向和MPC规划等。

### 主要变更

#### 配置文件改动 (`config/config.yaml`)
- 在 `visualization` 部分新增6个布尔配置项：
  - `image_enabled`：控制图像流发送
  - `visible_armors_enabled`：控制装甲可视化
  - `visible_robot_enabled`：控制机器人可视化
  - `camera_pose_enabled`：控制相机位置可视化
  - `aiming_direction_enabled`：控制瞄准方向可视化
  - `mpc_plan_enabled`：控制MPC规划可视化
- 重新组织了监控主机/端口/流类型的配置注释布局

#### 可视化模块改动 (`src/kernel/visualization.cpp`)
- 在 `Visualization::Impl::Config` 结构体中新增6个布尔字段，用于运行时控制各项可视化功能的启用状态
- 扩展了 `Config` 的序列化元数据 (`metas`)，包含所有新增布尔字段
- 将 `Config` 实例从 `initialize` 函数内的局部变量提升为 `Impl` 类成员变量
- 在 `send_image` 和各 `update_*` 方法中添加早期返回机制，根据对应的配置标志决定是否执行可视化操作

#### 运行时控制流改动 (`src/runtime.cpp`)
- 重新组织了目标追踪阶段的可视化调用逻辑：
  - `update_visible_robot()` 现在在获取预测装甲后立即调用
  - `update_aiming_direction()` 在完成火力控制求解后调用
  - `update_mpc_plan()` 现在条件性地执行，仅当 `command.feedforward_valid` 为真时才调用（之前无条件调用）
  
这一调整使MPC规划的可视化与前馈有效性状态保持同步，避免在无效前馈情况下进行不必要的可视化更新。

### 影响范围
- 公有API保持不变，所有改动均为内部实现细节
- 向后兼容：配置文件中的所有新增项均默认为 `true`，保持现有行为

<!-- end of auto-generated comment: release notes by coderabbit.ai -->