### PR TITLE
Fix/ekf update

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -54,9 +54,6 @@ identifier:
 tracker:
   # enemy_color: red
   enemy_color: blue
-  max_temporary_loss_frames: 4
-  max_unconfirmed_loss_frames: 2
-  tracking_confirm_frames: 2
 
 pose_estimator:
   yaw_optimizer: true
@@ -103,7 +100,6 @@ fire_control:
     near_angle_tolerance: 3 # degree
     far_angle_tolerance: 2 # degree
     split_distance: 2 # m
-    auto_fire: true
 
 visualization:
   framerate: 60

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -22,7 +22,7 @@ capturer:
     invert_image: false
     software_sync: false
     trigger_mode: false
-    fixed_framerate: false
+    fixed_framerate: true
   local_video:
     # 替换为你具体的路径
     location: "/path/to/your/video"

--- a/src/kernel/fire_control.cpp
+++ b/src/kernel/fire_control.cpp
@@ -76,8 +76,7 @@ struct FireControl::Impl {
         return {};
     }
 
-    auto solve(predictor::Snapshot const& snapshot, bool control, double current_yaw)
-        -> std::optional<Result> {
+    auto solve(predictor::Snapshot const& snapshot, double current_yaw) -> std::optional<Result> {
         auto target_solution = target_solution_solver.solve(
             snapshot, aim_point_chooser, config.initial_bullet_speed, config.shoot_delay);
         if (!target_solution.has_value()) return std::nullopt;
@@ -127,8 +126,6 @@ struct FireControl::Impl {
         pitch = pitch + config.pitch_offset;
 
         auto shoot_command = ShootEvaluator::Command {
-            .control            = control,
-            .auto_aim_enabled   = control,
             .yaw                = yaw,
             .center_position    = center_position,
             .aim_point_position = aim_point_position,
@@ -164,7 +161,7 @@ auto FireControl::initialize(const YAML::Node& yaml) noexcept -> std::expected<v
     return pimpl->initialize(yaml);
 }
 
-auto FireControl::solve(const predictor::Snapshot& snapshot, bool control, double current_yaw)
+auto FireControl::solve(const predictor::Snapshot& snapshot, double current_yaw)
     -> std::optional<Result> {
-    return pimpl->solve(snapshot, control, current_yaw);
+    return pimpl->solve(snapshot, current_yaw);
 }

--- a/src/kernel/fire_control.hpp
+++ b/src/kernel/fire_control.hpp
@@ -28,8 +28,7 @@ public:
 
     auto initialize(const YAML::Node&) noexcept -> std::expected<void, std::string>;
 
-    auto solve(const predictor::Snapshot& snapshot, bool control, double current_yaw)
-        -> std::optional<Result>;
+    auto solve(const predictor::Snapshot& snapshot, double current_yaw) -> std::optional<Result>;
 };
 
 } // namespace rmcs::kernel

--- a/src/module/fire_control/shoot_evaluator.cpp
+++ b/src/module/fire_control/shoot_evaluator.cpp
@@ -13,7 +13,6 @@ struct ShootEvaluator::Impl {
         double near_angle_tolerance { 4.0 };
         double far_angle_tolerance { 2.0 };
         double split_distance { 3.0 };
-        bool auto_fire { true };
         bool is_lazy_gimbal { false };
 
         constexpr static std::tuple metas {
@@ -23,8 +22,6 @@ struct ShootEvaluator::Impl {
             "far_angle_tolerance",
             &Config::split_distance,
             "split_distance",
-            &Config::auto_fire,
-            "auto_fire",
             &Config::is_lazy_gimbal,
             "is_lazy_gimbal",
         };
@@ -56,11 +53,6 @@ struct ShootEvaluator::Impl {
     auto evaluate(Command const& command, double current_yaw) noexcept -> bool {
         auto should_fire = false;
 
-        if (!command.control || !config.auto_fire) {
-            last_command_ = command;
-            return false;
-        }
-
         if (config.is_lazy_gimbal) {
             auto const aim_point_yaw =
                 std::atan2(command.aim_point_position.y(), command.aim_point_position.x());
@@ -78,7 +70,7 @@ struct ShootEvaluator::Impl {
             ? config.far_angle_tolerance
             : config.near_angle_tolerance;
 
-        if (last_command_.has_value() && command.auto_aim_enabled) {
+        if (last_command_.has_value()) {
             const auto yaw_delta =
                 std::abs(util::normalize_angle(last_command_->yaw - command.yaw));
             const auto track_delta =

--- a/src/module/fire_control/shoot_evaluator.hpp
+++ b/src/module/fire_control/shoot_evaluator.hpp
@@ -17,8 +17,6 @@ class ShootEvaluator {
 
 public:
     struct Command {
-        bool control { false };
-        bool auto_aim_enabled { false };
         double yaw { std::numeric_limits<double>::quiet_NaN() };
         Eigen::Vector3d center_position { Eigen::Vector3d::Zero() };
         Eigen::Vector3d aim_point_position { Eigen::Vector3d::Zero() };

--- a/src/module/predictor/regular/robot_state.cpp
+++ b/src/module/predictor/regular/robot_state.cpp
@@ -1,8 +1,9 @@
 #include "robot_state.hpp"
 
-#include <algorithm>
 #include <cmath>
 #include <limits>
+#include <numbers>
+#include <optional>
 #include <vector>
 
 #include "module/predictor/regular/snapshot.hpp"
@@ -11,34 +12,44 @@
 using namespace rmcs::predictor;
 
 struct RegularRobotState::Impl {
-    struct MatchResult {
-        int armor_id;
-        double error;
-        bool is_valid;
+    struct MatchDecision {
+        int matched_armor_id { kUnknownMatchedArmorId };
+        double error { std::numeric_limits<double>::infinity() };
+        bool is_valid { false };
+    };
+
+    struct BestMatch {
+        std::size_t observation_index;
+        MatchDecision decision;
     };
 
     DeviceId device { DeviceId::UNKNOWN };
     CampColor color { CampColor::UNKNOWN };
     int armor_num { 0 };
 
-    EKF ekf { EKF { } };
+    EKF ekf { EKF {} };
     TimePoint time_stamp;
 
     bool initialized { false };
     int update_count { 0 };
 
+    static constexpr int kUnknownMatchedArmorId = -1;
+    int last_matched_armor_id { kUnknownMatchedArmorId };
+
     const std::chrono::duration<double> reset_interval { 1.0 };
     const double angle_error_threshold { 0.65 };
+    const double visible_angle_threshold { std::numbers::pi / 2.0 };
 
     explicit Impl(TimePoint stamp) noexcept
         : time_stamp { stamp } { }
 
     auto initialize(Armor3D const& armor, TimePoint t) -> void {
-        device         = armor.genre;
-        color          = armor_color2camp_color(armor.color);
-        armor_num      = EKFParameters::armor_num(armor.genre);
-        time_stamp     = t;
-        update_count   = 0;
+        device                = armor.genre;
+        color                 = armor_color2camp_color(armor.color);
+        armor_num             = EKFParameters::armor_num(armor.genre);
+        time_stamp            = t;
+        update_count          = 0;
+        last_matched_armor_id = 0;
         ekf = EKF { EKFParameters::x(armor), EKFParameters::P_initial_dig(device).asDiagonal() };
         initialized = true;
     }
@@ -49,9 +60,10 @@ struct RegularRobotState::Impl {
         if (initialized) {
             auto dt = util::delta_time(t, time_stamp);
             if (dt > reset_interval) {
-                initialized  = false;
-                update_count = 0;
-                time_stamp   = t;
+                initialized           = false;
+                update_count          = 0;
+                last_matched_armor_id = kUnknownMatchedArmorId;
+                time_stamp            = t;
                 return;
             }
 
@@ -65,13 +77,21 @@ struct RegularRobotState::Impl {
     }
 
     auto update(std::span<Armor3D const> armors) -> bool {
-        bool fused = false;
-        for (auto const& armor : armors)
-            fused = update_single(armor) || fused;
+        if (armors.empty()) return false;
 
-        if (fused) ++update_count;
+        if (!initialized) {
+            initialize(armors.front(), time_stamp);
+            ++update_count;
+            return true;
+        }
 
-        return fused;
+        auto best_match = select_best_match(armors);
+        if (!best_match.has_value()) return false;
+
+        apply_match(armors, *best_match);
+        ++update_count;
+
+        return true;
     }
 
     auto is_converged() const -> bool {
@@ -83,7 +103,7 @@ struct RegularRobotState::Impl {
         auto const r_ok = (r > 0.05) && (r < 0.5);
         auto const l_ok = (l > 0.05) && (l < 0.5);
 
-        int min_updates = 3;
+        int const min_updates = 3;
         return r_ok && l_ok && update_count >= min_updates;
     }
 
@@ -98,8 +118,8 @@ struct RegularRobotState::Impl {
     }
 
 private:
-    auto match(Armor3D const& armor) const -> MatchResult {
-        if (!initialized || armor.genre != device) return { -1, 1e10, false };
+    auto decide_match(Armor3D const& armor) const -> MatchDecision {
+        if (!initialized || armor.genre != device) return {};
 
         auto armors_xyza = calculate_armors(ekf.x);
 
@@ -110,36 +130,58 @@ private:
         auto const ypr_in_world = util::eulers(orientation);
         auto const ypd_in_world = util::xyz2ypd(xyz);
 
-        auto it =
-            std::ranges::min_element(armors_xyza, [&](auto const& a_xyza, auto const& b_xyza) {
-                auto get_error = [&](auto const& pred) {
-                    auto ypd_pred = util::xyz2ypd(pred.template head<3>());
-                    return std::abs(util::normalize_angle(ypr_in_world[0] - pred[3]))
-                        + std::abs(util::normalize_angle(ypd_in_world[0] - ypd_pred[0]));
-                };
-
-                return get_error(a_xyza) < get_error(b_xyza);
-            });
-
-        auto const best_id   = static_cast<int>(std::distance(armors_xyza.begin(), it));
-        auto const min_error = [&] {
-            auto ypd_pred = util::xyz2ypd(it->template head<3>());
-            return std::abs(util::normalize_angle(ypr_in_world[0] - (*it)[3]))
-                + std::abs(util::normalize_angle(ypd_in_world[0] - ypd_pred[0]));
+        auto best_matched_armor_id           = kUnknownMatchedArmorId;
+        auto min_error                       = std::numeric_limits<double>::infinity();
+        auto const opposite_matched_armor_id = [&] {
+            if (armor_num != 4 || last_matched_armor_id == kUnknownMatchedArmorId) {
+                return kUnknownMatchedArmorId;
+            }
+            return (last_matched_armor_id + armor_num / 2) % armor_num;
         }();
 
-        return { best_id, min_error, min_error < angle_error_threshold };
+        for (auto&& [candidate_armor_id, pred] : armors_xyza | std::views::enumerate) {
+            if (candidate_armor_id == opposite_matched_armor_id) continue;
+
+            auto const ypd_pred   = util::xyz2ypd(pred.template head<3>());
+            auto const view_delta = std::abs(util::normalize_angle(pred[3] - ypd_pred[0]));
+            if (view_delta > visible_angle_threshold) continue;
+
+            auto const error = std::abs(util::normalize_angle(ypr_in_world[0] - pred[3]))
+                + std::abs(util::normalize_angle(ypd_in_world[0] - ypd_pred[0]));
+            if (error >= min_error) continue;
+
+            best_matched_armor_id = candidate_armor_id;
+            min_error             = error;
+        }
+
+        if (best_matched_armor_id == kUnknownMatchedArmorId) return {};
+
+        return {
+            .matched_armor_id = best_matched_armor_id,
+            .error            = min_error,
+            .is_valid         = min_error < angle_error_threshold,
+        };
     }
 
-    auto update_single(Armor3D const& armor) -> bool {
-        if (!initialized) {
-            initialize(armor, time_stamp);
-            return true;
-        }
-        if (armor.genre != device) return false;
+    auto select_best_match(std::span<Armor3D const> armors) const -> std::optional<BestMatch> {
+        auto best_match = std::optional<BestMatch> {};
+        for (std::size_t observation_index = 0; observation_index < armors.size();
+            ++observation_index) {
+            auto decision = decide_match(armors[observation_index]);
+            if (!decision.is_valid) continue;
+            if (best_match.has_value() && decision.error >= best_match->decision.error) continue;
 
-        auto match_result = match(armor);
-        if (!match_result.is_valid) return false;
+            best_match = { .observation_index = observation_index, .decision = decision };
+        }
+
+        return best_match;
+    }
+
+    auto apply_match(std::span<Armor3D const> armors, BestMatch const& best_match) -> void {
+        auto const& armor    = armors[best_match.observation_index];
+        auto const& decision = best_match.decision;
+
+        if (armor.genre != device) return;
 
         auto const [pos_x, pos_y, pos_z] = armor.translation;
         auto const xyz                   = Eigen::Vector3d { pos_x, pos_y, pos_z };
@@ -149,22 +191,22 @@ private:
         auto const orientation = Eigen::Quaterniond { quat_w, quat_x, quat_y, quat_z };
         auto const ypr         = util::eulers(orientation);
 
-        auto z = EKF::ZVec { };
+        auto z = EKF::ZVec {};
         z << ypd[0], ypd[1], ypd[2], ypr[0];
 
         ekf.update(
             z,
-            [id = match_result.armor_id, this](
+            [id = decision.matched_armor_id, this](
                 EKF::XVec const& x) { return EKFParameters::h(device, x, id, armor_num); },
-            [id = match_result.armor_id, this](
+            [id = decision.matched_armor_id, this](
                 EKF::XVec const& x) { return EKFParameters::H(device, x, id, armor_num); },
             EKFParameters::R(xyz, ypr, ypd), EKFParameters::x_add, EKFParameters::z_subtract);
 
-        return true;
+        last_matched_armor_id = decision.matched_armor_id;
     }
 
     auto calculate_armors(EKF::XVec const& x) const -> std::vector<Eigen::Vector4d> {
-        auto armors = std::vector<Eigen::Vector4d> { };
+        auto armors = std::vector<Eigen::Vector4d> {};
         armors.reserve(armor_num);
         for (int i = 0; i < armor_num; ++i) {
             auto angle = EKFParameters::armor_yaw(device, x, i);

--- a/src/module/tracker/decider.cpp
+++ b/src/module/tracker/decider.cpp
@@ -53,6 +53,7 @@ struct Decider::Impl {
             if (!trackers.contains(id)) {
                 trackers[id] = std::make_unique<RobotState>();
                 trackers[id]->initialize(grouped.front(), t);
+                last_seen_times[id] = t;
             }
 
             auto grouped_span = std::span<Armor3D const> { grouped.data(), grouped.size() };

--- a/src/module/tracker/decider.cpp
+++ b/src/module/tracker/decider.cpp
@@ -1,6 +1,5 @@
 #include "decider.hpp"
 #include "module/predictor/robot_state.hpp"
-#include "utility/serializable.hpp"
 #include "utility/time.hpp"
 
 #include <cmath>
@@ -17,30 +16,6 @@ using namespace std::chrono_literals;
 struct Decider::Impl {
     static constexpr auto kDefaultCleanupInterval = 1.0s;
     static constexpr auto kOutpostCleanupInterval = 1.5s;
-    static constexpr auto kReleaseAfterFrames     = std::size_t { 3 };
-
-    struct TargetMemory {
-        std::optional<TimePoint> last_seen_time { };
-        std::size_t consecutive_missing_frames { 0 };
-        std::size_t consecutive_stable_frames { 0 };
-        std::size_t consecutive_instable_frames { 0 };
-        bool temporary_lost_armed { false };
-    };
-
-    struct Config : util::Serializable {
-        std::size_t max_temporary_loss_frames { 5 };
-        std::size_t max_unconfirmed_loss_frames { 3 };
-        std::size_t tracking_confirm_frames { 3 };
-
-        constexpr static std::tuple metas {
-            &Config::max_temporary_loss_frames,
-            "max_temporary_loss_frames",
-            &Config::max_unconfirmed_loss_frames,
-            "max_unconfirmed_loss_frames",
-            &Config::tracking_confirm_frames,
-            "tracking_confirm_frames",
-        };
-    };
 
     static constexpr auto get_cleanup_interval(DeviceId device_id) {
         switch (device_id) {
@@ -52,20 +27,7 @@ struct Decider::Impl {
     }
 
     auto initialize(const YAML::Node& yaml) noexcept -> std::expected<void, std::string> {
-        auto result = config.serialize(yaml);
-        if (!result.has_value()) {
-            return std::unexpected { result.error() };
-        }
-
-        if (config.max_temporary_loss_frames == 0) {
-            return std::unexpected { "tracker.max_temporary_loss_frames must be > 0" };
-        }
-        if (config.max_unconfirmed_loss_frames == 0) {
-            return std::unexpected { "tracker.max_unconfirmed_loss_frames must be > 0" };
-        }
-        if (config.tracking_confirm_frames == 0) {
-            return std::unexpected { "tracker.tracking_confirm_frames must be > 0" };
-        }
+        std::ignore = yaml;
 
         if (priority_mode.empty()) priority_mode = mode2;
 
@@ -88,7 +50,6 @@ struct Decider::Impl {
         }
 
         for (auto& [id, grouped] : grouped_armors) {
-            auto& target_memory = target_memories[id];
             if (!trackers.contains(id)) {
                 trackers[id] = std::make_unique<RobotState>();
                 trackers[id]->initialize(grouped.front(), t);
@@ -99,53 +60,17 @@ struct Decider::Impl {
 
             if (fused) {
                 observed_ids.insert(id);
-                target_memory.last_seen_time             = t;
-                target_memory.consecutive_missing_frames = 0;
-            }
-        }
-
-        // 状态机：
-        // 1. unconfirmed: 已有 tracker，但还没稳定到可接管；
-        // 2. confirmed: 连续稳定若干帧后允许控制接管；
-        // 3. temporary lost: confirmed 目标短暂丢失时，保留控制输出窗口。
-        // 4. confirmed → unconfirmed: 需要连续不稳定 kReleaseAfterFrames 帧才释放
-        for (const auto& [id, tracker] : trackers) {
-            auto& target_memory         = target_memories[id];
-            auto was_tracking_confirmed = tracking_confirmed(id);
-
-            if (observed_ids.contains(id) && tracker->is_converged()) {
-                ++target_memory.consecutive_stable_frames;
-                target_memory.consecutive_instable_frames = 0;
-                target_memory.temporary_lost_armed        = false;
-                continue;
-            }
-
-            if (observed_ids.contains(id)) {
-                ++target_memory.consecutive_instable_frames;
-                if (target_memory.consecutive_instable_frames < kReleaseAfterFrames) {
-                    continue;
-                }
-            }
-
-            target_memory.consecutive_stable_frames = 0;
-            if (!observed_ids.contains(id)) {
-                if (was_tracking_confirmed) {
-                    target_memory.temporary_lost_armed = true;
-                }
-                ++target_memory.consecutive_missing_frames;
-            } else {
-                target_memory.temporary_lost_armed = false;
+                last_seen_times[id] = t;
             }
         }
 
         std::erase_if(trackers, [&](const auto& item) {
-            auto memory_it        = target_memories.find(item.first);
+            auto last_seen_it     = last_seen_times.find(item.first);
             auto cleanup_interval = get_cleanup_interval(item.first);
-            bool expired = memory_it == target_memories.end() || !memory_it->second.last_seen_time
-                || util::delta_time(t, *memory_it->second.last_seen_time) > cleanup_interval;
+            bool expired = last_seen_it == last_seen_times.end()
+                || util::delta_time(t, last_seen_it->second) > cleanup_interval;
             if (expired) {
-                if (item.first == primary_target_id) primary_target_id = DeviceId::UNKNOWN;
-                target_memories.erase(item.first);
+                last_seen_times.erase(item.first);
             }
 
             return expired;
@@ -153,22 +78,13 @@ struct Decider::Impl {
 
         auto fresh_target_id = arbitrate(observed_ids);
         if (fresh_target_id != DeviceId::UNKNOWN) {
-            primary_target_id = fresh_target_id;
-
-            auto confirmed = tracking_confirmed(primary_target_id);
-            return make_output(primary_target_id, confirmed, confirmed);
+            return make_output(fresh_target_id, trackers.at(fresh_target_id)->is_converged());
         }
 
-        if (auto output = hold_output(primary_target_id)) {
-            return std::move(*output);
-        }
-
-        primary_target_id = DeviceId::UNKNOWN;
         return Output {
-            .target_id          = DeviceId::UNKNOWN,
-            .snapshot           = std::nullopt,
-            .allow_control      = false,
-            .tracking_confirmed = false,
+            .target_id     = DeviceId::UNKNOWN,
+            .snapshot      = std::nullopt,
+            .allow_control = false,
         };
     }
 
@@ -187,55 +103,12 @@ struct Decider::Impl {
         return best_target_id;
     }
 
-    auto tracking_confirmed(DeviceId device_id) const -> bool {
-        auto memory_it = target_memories.find(device_id);
-        if (memory_it == target_memories.end()) {
-            return false;
-        }
-
-        return memory_it->second.consecutive_stable_frames >= config.tracking_confirm_frames;
-    }
-
-    auto make_output(DeviceId device_id, bool allow_takeover, bool confirmed) const -> Output {
+    auto make_output(DeviceId device_id, bool allow_takeover) const -> Output {
         return Output {
-            .target_id          = device_id,
-            .snapshot           = trackers.at(device_id)->get_snapshot(),
-            .allow_control      = allow_takeover,
-            .tracking_confirmed = confirmed,
+            .target_id     = device_id,
+            .snapshot      = trackers.at(device_id)->get_snapshot(),
+            .allow_control = allow_takeover,
         };
-    }
-
-    auto hold_output(DeviceId device_id) const -> std::optional<Output> {
-        if (device_id == DeviceId::UNKNOWN || !trackers.contains(device_id)) {
-            return std::nullopt;
-        }
-
-        const auto& target_tracker = *trackers.at(device_id);
-        const auto& target_memory  = target_memories.at(device_id);
-
-        if (target_tracker.is_converged()) {
-            if (target_memory.temporary_lost_armed
-                && is_within_loss_window(device_id, config.max_temporary_loss_frames)) {
-                return make_output(device_id, true, false);
-            }
-            return std::nullopt;
-        }
-
-        if (is_within_loss_window(device_id, config.max_unconfirmed_loss_frames)) {
-            return make_output(device_id, false, false);
-        }
-
-        return std::nullopt;
-    }
-
-    auto is_within_loss_window(DeviceId device_id, std::size_t max_missing_frames) const -> bool {
-        auto memory_it = target_memories.find(device_id);
-        if (device_id == DeviceId::UNKNOWN || !trackers.contains(device_id)
-            || memory_it == target_memories.end() || !memory_it->second.last_seen_time) {
-            return false;
-        }
-
-        return memory_it->second.consecutive_missing_frames <= max_missing_frames;
     }
 
     auto priority_of(DeviceId device_id) const -> int {
@@ -264,11 +137,9 @@ struct Decider::Impl {
         return rank(lhs) < rank(rhs);
     }
 
-    DeviceId primary_target_id { DeviceId::UNKNOWN };
     std::unordered_map<DeviceId, std::unique_ptr<RobotState>> trackers;
-    std::unordered_map<DeviceId, TargetMemory> target_memories;
+    std::unordered_map<DeviceId, TimePoint> last_seen_times;
 
-    Config config { };
     PriorityMode priority_mode;
 
     const PriorityMode mode1 = {

--- a/src/module/tracker/decider.hpp
+++ b/src/module/tracker/decider.hpp
@@ -22,7 +22,6 @@ public:
         DeviceId target_id;
         std::optional<predictor::Snapshot> snapshot;
         bool allow_control { false };
-        bool tracking_confirmed { false };
     };
 
     auto initialize(const YAML::Node& yaml) noexcept -> std::expected<void, std::string>;

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -184,9 +184,8 @@ auto main() -> int {
             auto armors    = snapshot->predicted_armors(Clock::now());
             visualization.update_visible_robot(armors);
 
-            const auto control = target.tracking_confirmed;
-            const auto yaw     = context.yaw;
-            if (auto result = fire_control.solve(*snapshot, control, yaw)) {
+            const auto yaw = context.yaw;
+            if (auto result = fire_control.solve(*snapshot, yaw)) {
                 command.should_control    = true;
                 command.target            = target.target_id;
                 command.should_shoot      = result->shoot_permitted;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 概述

本PR对扩展卡尔曼滤波（EKF）更新逻辑、跟踪决策与火控流程进行了重构与简化，移除若干冗余控制标志与配置，旨在提高系统稳定性并简化控制链路。

## 主要改动

### EKF 与机器人状态更新
- src/module/predictor/regular/robot_state.cpp
  - 重构装甲观测匹配与融合流程：由逐装甲逐次融合改为选取单个最佳观测进行融合（select_best_match / apply_match）。
  - 引入 MatchDecision 结构及 last_matched_armor_id 跟踪机制；增加“相反装甲”候选过滤（针对 4 装甲情况）。
  - 候选按可见角度和角度误差阈值筛选并以角度误差最小者为匹配；EKF 测量模型相应调整。
  - 在预测步骤中添加 last_matched_armor_id 重置逻辑与收敛门槛微调。

### 跟踪器状态管理重构
- src/module/tracker/decider.hpp / .cpp
  - Output 结构移除 tracking_confirmed，新增 allow_control（默认 false）。
  - 初始化不再解析/验证 YAML 配置（initialize 忽略 YAML 节点）。
  - 移除基于 TargetMemory 的状态机与暂存/确认逻辑；改为：
    - 预测已有 trackers、分组 incoming armors、按 device 更新或创建 RobotState；
    - 当 tracker 报告 fused 时记录 last_seen_times[id]；
    - 使用 last_seen_times 清理过期 tracker；
    - 直接仲裁当前观测并立即返回输出（不再维护 tracking_confirmed/持有逻辑）。
  - 内部存储由 target_memories/primary_target_id 简化为 last_seen_times 映射；make_output 简化为设置 target_id、snapshot 与 allow_control。

### 火控流程与射击评估简化
- src/kernel/fire_control.hpp / .cpp
  - FireControl::solve 方法签名变更：移除 bool control 参数，改为 solve(const predictor::Snapshot&, double current_yaw)。
  - 相应调用站点（如 src/runtime.cpp）已更新，移除 tracking_confirmed 作为参数传递。

- src/module/fire_control/shoot_evaluator.hpp / .cpp
  - ShootEvaluator::Command 中移除 control 与 auto_aim_enabled 两个布尔字段。
  - 移除 Config 中的 auto_fire 配置及其 YAML 序列化元数据。
  - evaluate() 不再基于 command.control 或 config.auto_fire 做早期返回；射击判断不再依赖 command.auto_aim_enabled，保留懒云台（lazy gimbal）重叠、角度阈值与 split_distance 等原有判断逻辑，按更新后的 last_command_ 流程决定是否开火。

### 配置与运行时调整
- config/config.yaml
  - capturer.hikcamera.fixed_framerate 从 false 改为 true。
  - tracker 配置移除三个调优参数：max_temporary_loss_frames、max_unconfirmed_loss_frames、tracking_confirm_frames。
  - shoot_evaluator 中移除 auto_fire 设置（其余参数保留）。

- src/runtime.cpp
  - fire_control.solve 的调用已移除对 tracking_confirmed 的传递（改为只传 snapshot 与 yaw）。

## 对外接口影响
- 公共 API 变化：
  - FireControl::solve 签名变化（移除 control 参数）— 需要更新所有调用方。
  - ShootEvaluator::Command 结构体移除两个布尔字段（可能影响构造/赋值处）。
  - Decider::Output 结构体字段变更（tracking_confirmed → allow_control）。

## 风险与注意事项
- 依赖 tracking_confirmed / control / auto_aim_enabled 语义的上层代码需调整以适配新接口与 allow_control 语义。
- EKF 匹配策略从多观测融合改为单观测融合，可能在特定场景下改变收敛/鲁棒性表现，建议在真实数据上进行回归验证。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Alliance-Algorithm/rmcs_auto_aim_v2/pull/48)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->