### PR TITLE
feat: add functionality for striking static outpost armors

### DIFF
--- a/src/module/fire_control/solver/target_solution_solver.cpp
+++ b/src/module/fire_control/solver/target_solution_solver.cpp
@@ -30,7 +30,8 @@ struct TargetSolutionSolver::Impl {
         for (int i = 0; i < kMaxIterateCount; ++i) {
             auto const total_predict_time = current_fly_time + shoot_delay;
             auto const t_target           = snapshot.time_stamp()
-                + std::chrono::duration_cast<Duration>(std::chrono::duration<double>(total_predict_time));
+                + std::chrono::duration_cast<Duration>(
+                    std::chrono::duration<double>(total_predict_time));
 
             auto predicted_kinematics = snapshot.kinematics_at(t_target);
             auto sample = AimPointSampler::sample_at(snapshot, chooser, t_target, bullet_speed);
@@ -39,10 +40,10 @@ struct TargetSolutionSolver::Impl {
             auto const time_error = std::abs(sample->attitude.fly_time - current_fly_time);
             current_fly_time      = sample->attitude.fly_time;
             best_candidate        = BestCandidate {
-                .attitude        = sample->attitude,
-                .impact_time     = t_target,
-                .center_position = predicted_kinematics.center_position,
-                .aim_point       = sample->aim_point,
+                       .attitude        = sample->attitude,
+                       .impact_time     = t_target,
+                       .center_position = predicted_kinematics.center_position,
+                       .aim_point       = sample->aim_point,
             };
             if (time_error < kMaxFlyTimeThreshold) break;
         }

--- a/src/module/predictor/outpost/robot_state.cpp
+++ b/src/module/predictor/outpost/robot_state.cpp
@@ -6,6 +6,7 @@
 #include <limits>
 #include <optional>
 #include <span>
+#include <utility>
 
 #include "module/predictor/outpost/snapshot.hpp"
 #include "utility/math/angle.hpp"
@@ -29,7 +30,6 @@ struct OutpostObservation {
     OutpostEKF::ZVec z;
     OutpostEKF::RMat R;
     Eigen::Vector3d xyz;
-    Eigen::Vector3d ypr;
     Eigen::Vector3d ypd;
 };
 
@@ -46,7 +46,7 @@ auto make_observation(rmcs::Armor3D const& armor) -> OutpostObservation {
     auto z = OutpostEKF::ZVec {};
     z << ypd[0], ypd[1], ypd[2], ypr[0];
 
-    return { z, OutpostEKFParameters::R(xyz, ypr, ypd), xyz, ypr, ypd };
+    return { z, OutpostEKFParameters::R(xyz, ypr, ypd), xyz, ypd };
 }
 
 enum class SwitchEvent {
@@ -85,39 +85,21 @@ struct MatchingConfig {
 struct TrackingConfig {
     std::chrono::duration<double> reset_interval { 1.5 };
     int spin_confirm_switches { 2 };
-    int min_converged_updates { 6 };
+    int stop_confirm_stays { 4 };
+    double stop_phase_rate_gate { 0.8 };
     MatchingConfig matching {};
 };
 
 struct SpinTracker {
-    int locked_sign { 0 };
-    int candidate_sign { 0 };
-    int candidate_count { 0 };
-    bool locked { false };
+    std::optional<int> confirmed_sign {};
+    std::optional<int> pending_sign {};
+    int pending_count { 0 };
+    int stop_pending_count { 0 };
+    std::optional<std::pair<double, rmcs::TimePoint>> last_stay_sample {};
 
     auto reset() -> void { *this = {}; }
 
-    auto current_sign() const -> int {
-        if (locked) return locked_sign;
-        return candidate_sign;
-    }
-
-    auto observe_switch(int inferred_spin_sign, int confirm_switches) -> void {
-        auto const normalized = normalize_spin_sign(inferred_spin_sign);
-        if (normalized == 0 || locked) return;
-
-        if (candidate_sign == normalized) {
-            candidate_count++;
-        } else {
-            candidate_sign  = normalized;
-            candidate_count = 1;
-        }
-
-        if (candidate_count < confirm_switches) return;
-
-        locked_sign = candidate_sign;
-        locked      = true;
-    }
+    auto current_sign() const -> int { return confirmed_sign.value_or(pending_sign.value_or(0)); }
 };
 
 auto assigned_count(OutpostArmorLayout const& layout) -> int {
@@ -187,17 +169,21 @@ public:
                                current_height, SwitchEvent::Stay, 0, false),
             best_decision);
 
-        if (spin_.locked) {
-            auto const event = spin_.locked_sign > 0 ? SwitchEvent::CounterClockwiseSwitch
-                                                     : SwitchEvent::ClockwiseSwitch;
-            consider_switch_direction(observation, current_phase, current_height, spin_.locked_sign,
-                event, best_decision);
-        } else {
-            consider_switch_direction(observation, current_phase, current_height, -1,
-                SwitchEvent::ClockwiseSwitch, best_decision);
-            consider_switch_direction(observation, current_phase, current_height, +1,
-                SwitchEvent::CounterClockwiseSwitch, best_decision);
+        if (spin_.confirmed_sign == 0) return best_decision;
+
+        if (spin_.confirmed_sign.has_value()) {
+            auto const sign = *spin_.confirmed_sign;
+            auto const event =
+                sign > 0 ? SwitchEvent::CounterClockwiseSwitch : SwitchEvent::ClockwiseSwitch;
+            consider_switch_direction(
+                observation, current_phase, current_height, sign, event, best_decision);
+            return best_decision;
         }
+
+        consider_switch_direction(observation, current_phase, current_height, -1,
+            SwitchEvent::ClockwiseSwitch, best_decision);
+        consider_switch_direction(observation, current_phase, current_height, +1,
+            SwitchEvent::CounterClockwiseSwitch, best_decision);
 
         return best_decision;
     }
@@ -349,11 +335,7 @@ struct OutpostRobotState::Impl {
         return true;
     }
 
-    auto is_converged() const -> bool {
-        return initialized && spin.locked
-            && assigned_count(layout) == OutpostEKFParameters::kOutpostArmorCount
-            && update_count >= config.min_converged_updates;
-    }
+    auto is_converged() const -> bool { return initialized && spin.confirmed_sign.has_value(); }
 
     auto get_snapshot() const -> Snapshot {
         return detail::make_outpost_snapshot(
@@ -393,6 +375,15 @@ private:
 
     auto apply_association(
         AssociationDecision const& decision, OutpostObservation const& observation) -> void {
+        auto const stay_ref_phase = [&]() -> std::optional<double> {
+            if (decision.event != SwitchEvent::Stay) return std::nullopt;
+
+            auto const slot_phase =
+                std::atan2(ekf.x[2] - observation.xyz[1], ekf.x[0] - observation.xyz[0]);
+            return rmcs::util::normalize_angle(
+                slot_phase - layout.slots[decision.armor_id].phase_offset);
+        }();
+
         auto const next_layout = layout_after_association(layout, decision);
 
         ekf.update(
@@ -405,9 +396,63 @@ private:
 
         layout           = next_layout;
         current_armor_id = decision.armor_id;
-        if (decision.event != SwitchEvent::Stay) {
-            spin.observe_switch(decision.inferred_spin_sign, config.spin_confirm_switches);
+
+        if (spin.confirmed_sign == 0) {
+            update_count++;
+            return;
         }
+
+        auto observe_pending = [&](int sign, int confirm_count) {
+            if (spin.pending_sign == sign) {
+                spin.pending_count++;
+            } else {
+                spin.pending_sign  = sign;
+                spin.pending_count = 1;
+            }
+
+            if (spin.pending_count >= confirm_count) {
+                spin.confirmed_sign = sign;
+                spin.pending_sign.reset();
+                spin.pending_count = 0;
+            }
+        };
+
+        if (decision.event != SwitchEvent::Stay) {
+            spin.last_stay_sample.reset();
+            spin.stop_pending_count = 0;
+
+            if (spin.pending_sign == 0) {
+                spin.pending_sign.reset();
+                spin.pending_count = 0;
+            }
+
+            if (!spin.confirmed_sign.has_value()) {
+                observe_pending(decision.inferred_spin_sign, config.spin_confirm_switches);
+            }
+        } else {
+            if (spin.last_stay_sample.has_value()) {
+                auto const [last_ref_phase, last_stay_stamp] = *spin.last_stay_sample;
+                auto const dt = rmcs::util::delta_time(time_stamp, last_stay_stamp).count();
+                if (dt > 0.0) {
+                    auto const phase_rate =
+                        std::abs(rmcs::util::normalize_angle(*stay_ref_phase - last_ref_phase))
+                        / dt;
+                    if (phase_rate < config.stop_phase_rate_gate) {
+                        spin.stop_pending_count++;
+                        if (spin.stop_pending_count >= config.stop_confirm_stays) {
+                            spin.confirmed_sign = 0;
+                            spin.pending_sign.reset();
+                            spin.pending_count = 0;
+                        }
+                    } else {
+                        spin.stop_pending_count = 0;
+                    }
+                }
+            }
+
+            spin.last_stay_sample = std::pair { *stay_ref_phase, time_stamp };
+        }
+
         update_count++;
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 功能概述

本PR为击打静止岗哨装甲增加了专门的功能支持。通过改进旋转（Spin）状态机的确认逻辑与停止检测机制，使系统能够准确识别岗哨机器人的旋转状态并检测其停止状态。

## 主要变更

### 1. `target_solution_solver.cpp` (低复杂度)
- 将目标时间戳 `t_target` 的计算表达式拆分为多行以提高可读性
- 调整 `BestCandidate` 结构体指定初始化的换行格式
- 逻辑语义保持不变，无公共接口修改

### 2. `robot_state.cpp` (高复杂度)

#### 状态机改进
- **SpinTracker 结构体重构**：
  - 引入 `pending_sign` 和 `confirmed_sign` 分离待确认和已确认的旋转方向
  - 引入 `last_stay_sample` 用于跟踪停留采样（记录相位和时间戳）
  - 新增 `stop_pending_count` 用于停止状态确认计数

#### 配置参数扩展
- TrackingConfig 新增参数：
  - `stop_confirm_stays`: 停止状态确认所需的停留样本数
  - `stop_phase_rate_gate`: 停止判定的相位率阈值

#### 关联决策引擎优化
- AssociationEngine::decide() 方法现基于 `spin_.confirmed_sign` 的值来确定切换方向候选
- 未确认时提供两个切换方向候选进行评估

#### 关联应用逻辑
- apply_association() 方法新增停留事件（Stay）的相位参考计算 (`stay_ref_phase`)
- 实现三层旋转状态管理：
  - 待确认阶段：通过多次切换事件累积确认
  - 已确认阶段：进行停止检测，统计连续停留样本的相位变化率
  - 停止检测：若相位率低于阈值且停留样本数达到确认次数，则标记旋转为停止

#### 观察结构简化
- OutpostObservation 移除 `ypr` 成员，只保留所需的 `ypd`（方向位置描述）

#### 收敛条件简化
- is_converged() 现仅依赖 `spin.confirmed_sign` 是否存在有效值，使判定更清晰直观

#### 依赖更新
- 新增 `<utility>` 头文件以支持使用的工具类型

## 技术亮点

通过引入分阶段的状态确认机制（待确认→已确认→停止检测），系统能够在动态变化和静态停留两种场景下准确跟踪岗哨机器人的旋转状态，为击打静止装甲提供了可靠的状态基础。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Alliance-Algorithm/rmcs_auto_aim_v2/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->