### PR TITLE
wip: visual and pnp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,5 +62,7 @@ $(ALLUSERSPROFILE)/
 # Local config override
 config/custom.yaml
 config/custom.yml
+config/unreal.yaml
+config/unreal.yml
 config/config.override.yaml
 config/config.override.yml

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -77,7 +77,7 @@ tracker:
   enemy_color: blue
 
 pose_estimator:
-  distance_optimizer: false
+  distance_optimizer: true
 
   fixed_outpost_pitch: true
   fixed_normal_pitch: false

--- a/src/kernel/pose_estimator.cpp
+++ b/src/kernel/pose_estimator.cpp
@@ -187,7 +187,6 @@ struct PoseEstimator::Impl {
                     result->predicted_near, std::back_inserter(addition.predicted_near));
                 std::ranges::copy(
                     result->predicted_away, std::back_inserter(addition.predicted_away));
-                std::ranges::copy(result->found, std::back_inserter(addition.detected_2d));
                 addition.center = result->center;
             }
 
@@ -209,7 +208,7 @@ struct PoseEstimator::Impl {
                     auto& result = outpost_optimizer.result;
 
                     // 只优化距离，旋转保持原来的
-                    // result.armor.orientation = outpost_in_camera.orientation;
+                    result.armor.orientation = outpost_in_camera.orientation;
 
                     outpost_in_camera = result.armor;
                     *outpost3d        = into_odom_link(result.armor);
@@ -229,10 +228,9 @@ struct PoseEstimator::Impl {
                     addition.detected_3d.push_back(into_odom_link(near_bar));
                     addition.detected_3d.push_back(into_odom_link(away_bar));
 
-                    const auto color      = ArmorVisualColor { lightbar.color };
                     const auto draw_color = std::array {
-                        cv::Scalar { color.b() * 255, color.g() * 255, color.r() * 255 } * 1.0,
-                        cv::Scalar { color.b() * 255, color.g() * 255, color.r() * 255 } * 0.5,
+                        cv::Scalar { 0, 255, 0 } * 1.0,
+                        cv::Scalar { 0, 255, 0 } * 0.5,
                     };
                     const auto bars = std::array { near_bar, away_bar };
                     for (const auto& [bar, color] : std::views::zip(bars, draw_color)) {
@@ -260,10 +258,11 @@ struct PoseEstimator::Impl {
 
                         if (!projection.solve()) continue;
 
+                        auto& result = projection.result;
                         addition.detected_2d.push_back(Lightbar2d {
                             .color      = bar.color,
-                            .upper      = Point2d { projection.result.projected_points[0] },
-                            .lower      = Point2d { projection.result.projected_points[1] },
+                            .upper      = Point2d { result.projected_points[0] },
+                            .lower      = Point2d { result.projected_points[1] },
                             .draw_color = color,
                         });
                     }

--- a/src/kernel/visualization.cpp
+++ b/src/kernel/visualization.cpp
@@ -6,6 +6,7 @@
 #include "utility/math/conversion.hpp"
 #include "utility/rclcpp/visual/armor.hpp"
 #include "utility/rclcpp/visual/arrow.hpp"
+#include "utility/rclcpp/visual/lightbar.hpp"
 #include "utility/rclcpp/visual/transform.hpp"
 #include "utility/serializable.hpp"
 
@@ -60,6 +61,7 @@ struct Visualization::Impl {
     std::unique_ptr<visual::Arrow> aiming_direction;
     std::unique_ptr<visual::Transform> camera_transform;
     std::unordered_map<std::string, visual::Armors> armor_publishers;
+    std::unordered_map<std::string, visual::Lightbars> lightbar_publishers;
 
     bool is_initialized  = false;
     bool size_determined = false;
@@ -159,6 +161,22 @@ struct Visualization::Impl {
         iter->second.update(armors);
     }
 
+    auto publish(std::span<const Lightbar3d> lightbars, const std::string& name) -> void {
+        if (!is_initialized) return;
+        if (!config.publishable) return;
+
+        auto iter = lightbar_publishers.find(name);
+        if (iter == lightbar_publishers.end()) {
+            auto config = visual::Lightbars::Config {
+                .rclcpp = rclcpp,
+                .name   = name,
+                .tf     = kOdomLink,
+            };
+            iter = lightbar_publishers.emplace(name, std::move(config)).first;
+        }
+        iter->second.update(lightbars);
+    }
+
     auto update_aiming_direction(double yaw, double pitch) const -> void {
         if (!is_initialized) return;
         if (!config.publishable) return;
@@ -174,10 +192,10 @@ struct Visualization::Impl {
         mpc_plan.publish_planned_pitch(pitch, pitch_rate, pitch_acc);
     }
 
-    auto update_camera_pose(const Orientation& orientation) const -> void {
+    auto update_camera_pose(const Transform& t) const -> void {
         if (!is_initialized) return;
         if (!config.publishable) return;
-        camera_transform->move(Translation::kZero(), orientation);
+        camera_transform->move(t.translation, t.orientation);
         camera_transform->update();
     }
 };
@@ -199,6 +217,11 @@ auto Visualization::publish(std::span<const Armor3d> armors, const std::string& 
     return pimpl->publish(armors, name);
 }
 
+auto Visualization::publish(std::span<const Lightbar3d> lightbars, const std::string& name)
+    -> void {
+    return pimpl->publish(lightbars, name);
+}
+
 auto Visualization::update_aiming_direction(double yaw, double pitch) const -> void {
     pimpl->update_aiming_direction(yaw, pitch);
 }
@@ -208,8 +231,8 @@ auto Visualization::update_mpc_plan(double yaw, double pitch, double yaw_rate, d
     pimpl->update_mpc_plan(yaw, pitch, yaw_rate, pitch_rate, yaw_acc, pitch_acc);
 }
 
-auto Visualization::update_camera_pose(const Orientation& orientation) const -> void {
-    pimpl->update_camera_pose(orientation);
+auto Visualization::update_camera_pose(const Transform& t) const -> void {
+    pimpl->update_camera_pose(t);
 }
 
 Visualization::Visualization() noexcept

--- a/src/kernel/visualization.hpp
+++ b/src/kernel/visualization.hpp
@@ -30,12 +30,17 @@ public:
     auto update_mpc_plan(double yaw, double pitch, double yaw_rate, double pitch_rate,
         double yaw_acc, double pitch_acc) const -> void;
 
-    auto update_camera_pose(const Orientation&) const -> void;
+    auto update_camera_pose(const Transform&) const -> void;
 
     auto publish(const Armor3d& armor, const std::string& name) -> void {
         publish(std::span<const Armor3d> { &armor, 1 }, name);
     }
     auto publish(std::span<const Armor3d> armors, const std::string& name) -> void;
+
+    auto publish(const Lightbar3d& lightbar, const std::string& name) -> void {
+        publish(std::span<const Lightbar3d> { &lightbar, 1 }, name);
+    }
+    auto publish(std::span<const Lightbar3d> lightbars, const std::string& name) -> void;
 
     template <drawable_trait T>
     auto draw_later(const T& drawable) {

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -117,13 +117,13 @@ auto main() -> int {
         auto context = SystemContext::kIdentity();
         if (!localhost_develop) {
             using namespace std::chrono_literals;
-            const auto timestamp = image->get_timestamp() - 6'250'000ns;
+            const auto timestamp = image->get_timestamp() - 8'200'000ns;
             const auto closest   = feishu.search(timestamp, 50ms);
             if (!closest) continue;
 
             context = *closest;
         }
-        visualization.update_camera_pose(context.camera_transform.orientation);
+        visualization.update_camera_pose(context.camera_transform);
 
         if (framerate.tick()) {
             node.info("Autoaim Framerate: {}", framerate.fps());
@@ -170,8 +170,8 @@ auto main() -> int {
             auto result = pose_estimator.estimate_armor(armors_2d, *image);
 
             const auto& addition = pose_estimator.addition();
-            visualization.draw_later(addition.areas);
             visualization.draw_later(addition.detected_2d);
+            visualization.draw_later(addition.areas);
             visualization.draw_later(addition.predicted_near);
             visualization.draw_later(addition.predicted_away);
             visualization.publish(addition.origin, "origin_armors");

--- a/src/utility/logging/eigen.hpp
+++ b/src/utility/logging/eigen.hpp
@@ -23,8 +23,8 @@ template <>
 struct std::formatter<Eigen::Vector3d> : EigenFormatterBase {
     auto format(const Eigen::Vector3d& v, std::format_context& ctx) const {
         if (precision >= 0) {
-            return std::format_to(ctx.out(), "({:.{}f}, {:.{}f}, {:.{}f})", v.x(), precision, v.y(),
-                precision, v.z(), precision);
+            return std::format_to(ctx.out(), "({:+.{}f}, {:+.{}f}, {:+.{}f})", v.x(), precision,
+                v.y(), precision, v.z(), precision);
         }
         return std::format_to(ctx.out(), "({}, {}, {})", v.x(), v.y(), v.z());
     }
@@ -34,7 +34,7 @@ template <>
 struct std::formatter<Eigen::Quaterniond> : EigenFormatterBase {
     auto format(const Eigen::Quaterniond& q, std::format_context& ctx) const {
         if (precision >= 0) {
-            return std::format_to(ctx.out(), "(w={:.{}f}, {:.{}f}, {:.{}f}, {:.{}f})", q.w(),
+            return std::format_to(ctx.out(), "(w={:+.{}f}, {:+.{}f}, {:+.{}f}, {:+.{}f})", q.w(),
                 precision, q.x(), precision, q.y(), precision, q.z(), precision);
         }
         return std::format_to(ctx.out(), "(w={}, {}, {}, {})", q.w(), q.x(), q.y(), q.z());

--- a/src/utility/math/camera.hpp
+++ b/src/utility/math/camera.hpp
@@ -14,8 +14,6 @@ struct CameraFeature {
     // Distortion coefficients (k1, k2, p1, p2, k3)
     std::array<double, 5> distort_coeff;
 
-    // World-to-camera extrinsic transform (ROS convention)
-    //   p_camera = quaternion * p_world + translation
     Orientation orientation { Orientation::kIdentity() };
     Translation translation { Translation::kZero() };
 

--- a/src/utility/math/outpost.cpp
+++ b/src/utility/math/outpost.cpp
@@ -1,6 +1,5 @@
 #include "utility/math/outpost.hpp"
 #include "utility/robot/constant.hpp"
-
 #include <eigen3/Eigen/Geometry>
 
 namespace rmcs::util {
@@ -11,25 +10,28 @@ auto NeighborBarSolution::solve() -> void {
 
     const auto& armor = input.source;
 
-    // 先求出旋转中心，按照装甲板的朝向反推即可，注意 15 度的倾角
-    const auto horizon_toward = Eigen::Vector3d { armor.orientation.make<Eigen::Quaterniond>()
-        * Eigen::AngleAxisd { -pitch, Eigen::Vector3d::UnitY() } * Eigen::Vector3d::UnitX() }
-                                    .normalized();
-    const auto vertical_axis  = Eigen::Vector3d {
-        (armor.orientation.make<Eigen::Quaterniond>() * Eigen::Vector3d::UnitZ()).normalized()
-    };
-    const auto outpost_center =
-        Eigen::Vector3d { armor.translation.make<Eigen::Vector3d>() + horizon_toward * radius };
+    const auto q = armor.orientation.make<Eigen::Quaterniond>();
+    const auto t = armor.translation.make<Eigen::Vector3d>();
 
-    result.center = Point3d { outpost_center };
+    // 先求出旋转中心，按照装甲板的朝向反推即可，注意 15 度的倾角
+    const auto backward = Eigen::Vector3d { q * Eigen::Vector3d::UnitX() };
+    const auto armor2center =
+        Eigen::Vector3d { Eigen::AngleAxisd { -pitch, q * Eigen::Vector3d::UnitY() } * backward };
+
+    const auto rotation_center = Eigen::Vector3d { t + radius * armor2center };
+
+    // 前哨站向上的单位向量，即水平向量绕 Y 轴朝向旋转 90 度
+    const auto vertical = Eigen::Vector3d {
+        Eigen::AngleAxisd { -0.5 * std::numbers::pi, q * Eigen::Vector3d::UnitY() } * armor2center
+    };
 
     // 逆时针旋转为正，所以在右边需要 +，旋转 1/3 个圆
     const auto rotate_sign = input.in_right ? +1 : -1;
     const auto rotate2next =
-        Eigen::AngleAxisd { rotate_sign * 2 * std::numbers::pi / 3., vertical_axis };
+        Eigen::AngleAxisd { rotate_sign * 2 * std::numbers::pi / 3., vertical };
 
     const auto next_center =
-        Eigen::Vector3d { outpost_center + rotate2next * (-horizon_toward * radius) };
+        Eigen::Vector3d { rotation_center + rotate2next * (-armor2center * radius) };
 
     const auto steps = std::array {
         (input.in_right ? +2 : +1) * kOutpostArmorHeightStep,
@@ -37,12 +39,12 @@ auto NeighborBarSolution::solve() -> void {
     };
     const auto flags = std::array { true, false };
     for (auto&& [step, is_upper] : std::views::zip(steps, flags)) {
-        const auto center = Eigen::Vector3d { next_center + vertical_axis * step };
+        const auto center = Eigen::Vector3d { next_center + vertical * step };
         const auto toward = Eigen::Vector3d { rotate2next
             * armor.orientation.make<Eigen::Quaterniond>() * Eigen::Vector3d::UnitX() };
 
         const auto x_axis = Eigen::Vector3d { toward.normalized() };
-        const auto y_axis = Eigen::Vector3d { vertical_axis.cross(x_axis).normalized() };
+        const auto y_axis = Eigen::Vector3d { vertical.cross(x_axis).normalized() };
         const auto z_axis = Eigen::Vector3d { x_axis.cross(y_axis).normalized() };
 
         const auto y_step = 0.5 * kSmallArmorWidth;
@@ -73,6 +75,8 @@ auto NeighborBarSolution::solve() -> void {
         // 根据上下侧来选定赋值目标
         (is_upper ? result.upper_near : result.lower_near) = near;
         (is_upper ? result.upper_away : result.lower_away) = away;
+
+        result.center = rotation_center;
     }
 }
 

--- a/src/utility/math/solve_pnp/pnp_solution.cpp
+++ b/src/utility/math/solve_pnp/pnp_solution.cpp
@@ -144,13 +144,6 @@ auto RobustPnpSolution::solve() -> bool {
         const auto camera_to_armor = t_camera_armor.normalized();
         if (back_direction.dot(camera_to_armor) <= 0.0) continue;
 
-        // [剪枝] 去除相机系下朝向偏转过大的装甲板
-        const auto limit = deg2rad(input.max_yaw_pitch);
-        const auto ypr   = eulers(q_camera_armor, 2, 1, 0);
-        if (std::abs(ypr[0]) > limit || std::abs(ypr[1]) > limit) {
-            continue;
-        }
-
         // [剪枝] 去除 Odom 系下，Pitch 不合理的装甲板，前哨站朝下，其余朝上
         const auto pitch = eulers(q_odom_armor, 2, 1, 0)[1];
         if (pitch * pitch_sign <= 0.0) continue;
@@ -183,7 +176,7 @@ auto RobustPnpSolution::solve() -> bool {
         const auto ypr       = eulers(q_initial, 2, 1, 0);
 
         auto origin_yaw   = ypr[0];
-        auto origin_pitch = pitch_sign * std::abs(ypr[1]);
+        auto origin_pitch = ypr[1];
         if (input.fixed_outpost_pitch && armor2d.genre == ArmorGenre::OUTPOST) {
             origin_pitch = kPredictedOutpostArmorPitch;
         }
@@ -232,7 +225,7 @@ auto RobustPnpSolution::solve() -> bool {
 
         const auto area  = deg2rad(kYawOptimizeRange * 0.5);
         const auto step  = deg2rad(kYawOptimizeStep);
-        const auto steps = std::round((area * 2.0) / step);
+        const auto steps = static_cast<int>(std::round((area * 2.0) / step));
 
         // 搜索最小重投影误差
         auto optimized_yaw   = origin_yaw;

--- a/src/utility/math/solve_pnp/pnp_solution.hpp
+++ b/src/utility/math/solve_pnp/pnp_solution.hpp
@@ -44,7 +44,6 @@ struct RobustPnpSolution {
 
         bool fixed_outpost_pitch = false;
         bool fixed_normal_pitch  = false;
-        double max_yaw_pitch     = 60;
     } input;
 
     struct Result {

--- a/src/utility/rclcpp/visual/armor.cpp
+++ b/src/utility/rclcpp/visual/armor.cpp
@@ -37,7 +37,7 @@ auto make_armor_marker(const std::string& frame_id, const std::string& ns, int i
     marker.id              = id;
     marker.type            = Marker::CUBE;
     marker.action          = Marker::ADD;
-    marker.lifetime        = rclcpp::Duration::from_seconds(0.1);
+    marker.lifetime        = rclcpp::Duration::from_seconds(0.5);
 
     ArmorVisualScale { armor.genre }.to(marker.scale);
     ArmorVisualColor { armor_color2camp_color(armor.color) }.to(marker.color);
@@ -56,7 +56,7 @@ auto make_arrow_marker(const std::string& frame_id, const std::string& ns, int i
     marker.id              = id;
     marker.type            = Marker::ARROW;
     marker.action          = Marker::ADD;
-    marker.lifetime        = rclcpp::Duration::from_seconds(1);
+    marker.lifetime        = rclcpp::Duration::from_seconds(0.5);
 
     marker.scale.x = 0.2;
     marker.scale.y = 0.01;
@@ -104,7 +104,7 @@ struct Armor::Impl {
         marker.id              = config.id;
         marker.type            = Marker::CUBE;
         marker.action          = Marker::ADD;
-        marker.lifetime        = rclcpp::Duration::from_seconds(0.1);
+        marker.lifetime        = rclcpp::Duration::from_seconds(0.5);
 
         ArmorVisualScale { config.device }.to(marker.scale);
         ArmorVisualColor { config.camp }.to(marker.color);
@@ -114,7 +114,7 @@ struct Armor::Impl {
         arrow_marker.id              = config.id;
         arrow_marker.type            = Marker::ARROW;
         arrow_marker.action          = Marker::ADD;
-        arrow_marker.lifetime        = rclcpp::Duration::from_seconds(0.1);
+        arrow_marker.lifetime        = rclcpp::Duration::from_seconds(0.5);
 
         arrow_marker.scale.x = 0.2;
         arrow_marker.scale.y = 0.01;

--- a/src/utility/rclcpp/visual/lightbar.cpp
+++ b/src/utility/rclcpp/visual/lightbar.cpp
@@ -3,9 +3,12 @@
 #include "utility/panic.hpp"
 #include "utility/rclcpp/node.details.hpp"
 
+#include <format>
 #include <geometry_msgs/msg/point.hpp>
 #include <visualization_msgs/msg/marker.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
 
+using namespace rmcs;
 using namespace rmcs::util::visual;
 
 using Marker = visualization_msgs::msg::Marker;
@@ -93,3 +96,99 @@ LightBar::LightBar(const Config& config) noexcept
     : pimpl { std::make_unique<Impl>(config) } { }
 
 LightBar::~LightBar() noexcept = default;
+
+using MarkerArray = visualization_msgs::msg::MarkerArray;
+
+struct Lightbars::Impl {
+    static inline rclcpp::Clock rclcpp_clock { RCL_STEADY_TIME };
+
+    Config config;
+
+    std::shared_ptr<rclcpp::Publisher<MarkerArray>> rclcpp_pub;
+    std::size_t previous_size = 0;
+
+    explicit Impl(Config config) noexcept
+        : config { std::move(config) } {
+        if (!prefix::check_naming(this->config.name) || !prefix::check_naming(this->config.tf)) {
+            util::panic(std::format(
+                "Not a valid naming for lightbars name or tf: {}", prefix::naming_standard));
+        }
+    }
+
+    static auto create_rclcpp_publisher(const Config& config) noexcept
+        -> std::shared_ptr<rclcpp::Publisher<MarkerArray>> {
+        const auto topic_name = config.rclcpp.get_pub_topic_prefix() + config.name;
+        return config.rclcpp.details->make_pub<MarkerArray>(topic_name, qos::debug);
+    }
+
+    auto make_marker(int id, const Lightbar3d& bar, const rclcpp::Time& stamp) const noexcept
+        -> Marker {
+        auto marker            = Marker { };
+        marker.header.frame_id = config.tf;
+        marker.header.stamp    = stamp;
+        marker.ns              = config.name;
+        marker.id              = id;
+        marker.type            = Marker::LINE_LIST;
+        marker.action          = Marker::ADD;
+        marker.lifetime        = rclcpp::Duration::from_seconds(0.5);
+
+        marker.scale.x = 0.01;
+
+        ArmorVisualColor { bar.color }.to(marker.color);
+
+        marker.points.resize(2);
+        marker.points[0].x = bar.upper.x;
+        marker.points[0].y = bar.upper.y;
+        marker.points[0].z = bar.upper.z;
+        marker.points[1].x = bar.lower.x;
+        marker.points[1].y = bar.lower.y;
+        marker.points[1].z = bar.lower.z;
+
+        return marker;
+    }
+
+    auto make_delete_marker(int id, const rclcpp::Time& stamp) const noexcept -> Marker {
+        auto marker            = Marker { };
+        marker.header.frame_id = config.tf;
+        marker.header.stamp    = stamp;
+        marker.ns              = config.name;
+        marker.id              = id;
+        marker.type            = Marker::LINE_LIST;
+        marker.action          = Marker::DELETE;
+        return marker;
+    }
+
+    auto update(std::span<const Lightbar3d> lightbars) noexcept -> void {
+        if (!rclcpp_pub) {
+            rclcpp_pub = create_rclcpp_publisher(config);
+        }
+
+        auto visual_marker = MarkerArray { };
+        const auto stamp   = rclcpp_clock.now();
+
+        for (int i = 0; i < static_cast<int>(lightbars.size()); ++i) {
+            visual_marker.markers.emplace_back(make_marker(i, lightbars[i], stamp));
+        }
+
+        for (std::size_t i = lightbars.size(); i < previous_size; ++i) {
+            visual_marker.markers.emplace_back(
+                make_delete_marker(static_cast<int>(i), stamp));
+        }
+
+        previous_size = lightbars.size();
+        rclcpp_pub->publish(visual_marker);
+    }
+};
+
+auto Lightbars::update(std::span<const Lightbar3d> lightbars) noexcept -> void {
+    pimpl->update(lightbars);
+}
+
+Lightbars::Lightbars(Config config) noexcept
+    : pimpl { std::make_unique<Impl>(std::move(config)) } { }
+
+Lightbars::~Lightbars() noexcept = default;
+
+Lightbars::Lightbars(Lightbars&&) noexcept = default;
+
+auto Lightbars::operator=(Lightbars&&) noexcept -> Lightbars& = default;

--- a/src/utility/rclcpp/visual/lightbar.hpp
+++ b/src/utility/rclcpp/visual/lightbar.hpp
@@ -5,6 +5,7 @@
 #include "utility/robot/armor.hpp"
 
 #include <memory>
+#include <span>
 #include <string>
 
 namespace rmcs::util::visual {
@@ -46,6 +47,31 @@ public:
     auto set_color(float r, float g, float b, float a = 1.0) noexcept -> void;
 
     auto update() noexcept -> void;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> pimpl;
+};
+
+struct Lightbars {
+public:
+    struct Config {
+        RclcppNode& rclcpp;
+
+        std::string name;
+        std::string tf;
+    };
+
+    explicit Lightbars(Config) noexcept;
+
+    ~Lightbars() noexcept;
+
+    Lightbars(const Lightbars&)            = delete;
+    Lightbars& operator=(const Lightbars&) = delete;
+    Lightbars(Lightbars&&) noexcept;
+    Lightbars& operator=(Lightbars&&) noexcept;
+
+    auto update(std::span<const Lightbar3d> lightbars) noexcept -> void;
 
 private:
     struct Impl;

--- a/tool/cxx/see_outpost.cpp
+++ b/tool/cxx/see_outpost.cpp
@@ -31,11 +31,11 @@ auto main() -> int {
 
     while (rclcpp::ok()) {
         const auto stamp = node.details->rclcpp->now();
-        const auto speed = kOutpostAngularSpeed * 0.1;
-        double elapsed =
+        const auto speed = kOutpostAngularSpeed;
+        const auto elapsed =
             std::chrono::duration<double>(std::chrono::steady_clock::now() - start_time).count();
-        double angle = speed * elapsed;
-        Eigen::Vector3d position { center.x() + kOutpostRadius * std::cos(angle),
+        const auto angle    = speed * elapsed;
+        const auto position = Eigen::Vector3d { center.x() + kOutpostRadius * std::cos(angle),
             center.y() + kOutpostRadius * std::sin(angle), center.z() };
 
         const auto direction = position - center;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 摘要

该PR对视觉和PnP求解系统进行了多项优化和功能增强。

## 核心改动

### 可视化系统升级
- **灯条可视化支持**：新增 `Lightbars` 类用于批量管理和发布灯条三维可视化，支持按名称缓存对应的ROS2发布器，并能够生成LINE_LIST类型的Marker进行可视化渲染。
- **相机位姿接口统一**：将 `Visualization::update_camera_pose` 的参数从单纯的 `Orientation` 改为接收完整的 `Transform` 对象，以支持位姿的整体更新。
- **标记显示时长调整**：调整装甲和箭头标记的显示时长为0.5秒，使得可视化效果更加一致。

### PnP求解算法优化
- **简化候选筛选逻辑**：移除基于欧拉角幅度的"过大偏转"剪枝逻辑，仅保留背向剔除和Pitch合理性检验。
- **参数精简**：移除了 `RobustPnpSolution::Input` 中的 `max_yaw_pitch` 成员，简化输入配置。
- **改进Pitch计算**：优化了重投影优化阶段中原始Pitch的初始计算方式。

### 姿态估计改进
- **前哨站几何计算重写**：将 `NeighborBarSolution::solve()` 中的几何计算逻辑从基于坐标轴推导改为基于装甲板姿态四元数与平移量进行计算，提高了计算的数值稳定性。
- **灯条坐标系优化**：调整灯条y轴的基准向量计算方式。
- **可视化颜色简化**：在调试绘制中将动态颜色计算替换为固定的绿色标量。

### 运行时优化
- **时间戳偏移调整**：将图像时间戳匹配飞书数据的时间偏移从 `-6'250'000ns` 调整为 `-8'200'000ns`。
- **相机位姿更新方式改变**：运行时中的相机位姿更新改为直接使用完整的 `camera_transform` 而非仅使用orientation。
- **渲染顺序调整**：交换了检测结果和区域的渲染顺序。
- **前哨站角速度计算**：移除了角速度计算中的0.1倍数因子，直接使用标定的角速度值。

### 工具和格式改进
- **日志输出格式**：更新Eigen类型（Vector3d、Quaterniond）的格式化输出，使其显示带有显式的正负号。
- **配置管理**：在.gitignore中新增对Unreal引擎本地配置文件的忽略规则。
- **.hpp注释清理**：移除了CameraFeature结构体中的冗余注释。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->