### PR TITLE
feat: record video while autoaim is running

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -20,6 +20,13 @@ capturer:
   show_loss_framerate_interval: 500
   reconnect_wait_interval: 100
 
+  record_enable: false
+  saving_pathes:
+    ["/home/root/autoaim/", "/home/ubuntu/autoaim/", "/tmp/autoaim/"]
+  max_duration_seconds: 60
+  record_fps: 24
+  max_videos_size_gb: 50
+
   # source: "local_video"
   source: "hikcamera"
 

--- a/src/kernel/capturer.cpp
+++ b/src/kernel/capturer.cpp
@@ -3,13 +3,17 @@
 #include "module/capturer/hikcamera.hpp"
 #include "module/capturer/local_video.hpp"
 #include "utility/framerate.hpp"
+#include "utility/image/image.details.hpp"
+#include "utility/image/recorder.hpp"
 #include "utility/logging/printer.hpp"
+#include "utility/service.hpp"
 #include "utility/singleton/running.hpp"
 #include "utility/thread/spsc_queue.hpp"
 #include "utility/times_limit.hpp"
 
-#include <rclcpp/utilities.hpp>
+#include <ranges>
 #include <thread>
+#include <vector>
 
 using namespace rmcs::kernel;
 using namespace rmcs::cap;
@@ -17,18 +21,83 @@ using namespace rmcs::cap;
 struct Capturer::Impl {
     using RawImage = Image*;
 
+    struct Config : util::Serializable {
+        std::string source;
+        bool show_loss_framerate;
+        int show_loss_framerate_interval;
+        int reconnect_wait_interval;
+        bool record_enable;
+        std::vector<std::string> saving_pathes;
+        int max_duration_seconds;
+        std::size_t record_fps;
+        std::uintmax_t max_videos_size_gb;
+
+        // clang-format off
+        static constexpr std::tuple metas {
+            &Config::source,                    "source",
+            &Config::show_loss_framerate,       "show_loss_framerate",
+            &Config::show_loss_framerate_interval, "show_loss_framerate_interval",
+            &Config::reconnect_wait_interval,   "reconnect_wait_interval",
+            &Config::record_enable,             "record_enable",
+            &Config::saving_pathes,             "saving_pathes",
+            &Config::max_duration_seconds,      "max_duration_seconds",
+            &Config::record_fps,                "record_fps",
+            &Config::max_videos_size_gb,        "max_videos_size_gb",
+        };
+        // clang-format on
+    } config;
+
     std::unique_ptr<Interface> interface;
 
     Printer log { "Capturer" };
     FramerateCounter loss_image_framerate { };
 
-    std::chrono::milliseconds reconnect_wait_interval { 500 };
-
     util::spsc_queue<Image*, 10> capture_queue;
     std::jthread runtime_thread;
 
+    VideoRecorder recorder { };
+
+    std::atomic<std::int8_t> record_request = 0;
+    std::jthread service_thread { [this](const std::stop_token& token) {
+        using namespace util;
+        auto service = Service {
+            Named<"cap"> { },
+            Action { Named<"record">(),
+                [this](std::string_view data) {
+                    constexpr auto kT = std::array { "1", "true" };
+                    constexpr auto kF = std::array { "0", "false" };
+
+                    const auto lower = std::ranges::to<std::string>(data
+                        | std::views::drop_while([](char c) { return c == '\n' || c == '\r'; })
+                        | std::views::reverse
+                        | std::views::drop_while([](char c) { return c == '\n' || c == '\r'; })
+                        | std::views::reverse | std::views::transform(::tolower));
+                    const auto equal = [&](std::string_view target) {
+                        return std::ranges::equal(lower, target);
+                    };
+                    /*^^*/ if (std::ranges::any_of(kT, equal)) {
+                        record_request = +1;
+                    } else if (std::ranges::any_of(kF, equal)) {
+                        record_request = -1;
+                    } else {
+                        log.error("无法处理请求: {}, 忽略", data);
+                    }
+                } },
+        };
+        while (!token.stop_requested()) {
+            service.spin();
+
+            using namespace std::chrono_literals;
+            std::this_thread::sleep_for(100ms);
+        }
+    } };
+
     auto initialize(const YAML::Node& yaml) noexcept -> Result try {
-        auto source = yaml["source"].as<std::string>();
+        if (auto result = config.serialize(yaml); !result.has_value()) {
+            return std::unexpected { result.error() };
+        }
+
+        auto& source = config.source;
 
         auto instantitation_result = std::expected<void, std::string> {
             std::unexpected { "Unknown capturer source or not implemented source" },
@@ -50,7 +119,7 @@ struct Capturer::Impl {
             interface = std::move(instance);
         };
 
-        /*  */ if (source == "hikcamera") {
+        /*^^*/ if (source == "hikcamera") {
             system_instantiation.operator()<Hikcamera>(source);
         } else if (source == "local_video") {
             system_instantiation.operator()<LocalVideo>(source);
@@ -61,19 +130,21 @@ struct Capturer::Impl {
             return std::unexpected { instantitation_result.error() };
         }
 
-        auto show_loss_framerate          = yaml["show_loss_framerate"].as<bool>();
-        auto show_loss_framerate_interval = yaml["show_loss_framerate_interval"].as<int>();
-
-        loss_image_framerate.enable = show_loss_framerate;
+        loss_image_framerate.enable = config.show_loss_framerate;
         loss_image_framerate.set_interval(
-            std::chrono::milliseconds { show_loss_framerate_interval });
-
-        reconnect_wait_interval =
-            std::chrono::milliseconds { yaml["reconnect_wait_interval"].as<int>() };
+            std::chrono::milliseconds { config.show_loss_framerate_interval });
 
         runtime_thread = std::jthread {
             [this](const auto& t) { runtime_task(t); },
         };
+
+        recorder.update_config({
+            .directories     = config.saving_pathes,
+            .max_duration    = std::chrono::seconds { config.max_duration_seconds },
+            .record_fps      = config.record_fps,
+            .max_videos_size = config.max_videos_size_gb * 1024 * 1024 * 1024,
+        });
+
         return { };
 
     } catch (const std::exception& e) {
@@ -103,6 +174,8 @@ struct Capturer::Impl {
         // Success context
         auto success_callback = [&](std::unique_ptr<Image> image) {
             auto newest = image.release();
+            recorder.tick(newest->details().mat);
+
             if (!capture_queue.push(newest)) {
 
                 // Failed to push, drop the oldest one
@@ -136,7 +209,8 @@ struct Capturer::Impl {
                 log.error("- Newest error: {}", msg);
                 log.error("- Reconnect capturer now...");
 
-                rclcpp::sleep_for(reconnect_wait_interval);
+                std::this_thread::sleep_for(
+                    std::chrono::milliseconds { config.reconnect_wait_interval });
                 capture_failed_limit.reset();
             }
         };
@@ -158,19 +232,34 @@ struct Capturer::Impl {
                     log.error("{} times, stop printing errors", error_limit.count);
                 }
             }
-            rclcpp::sleep_for(reconnect_wait_interval);
+            std::this_thread::sleep_for(
+                std::chrono::milliseconds { config.reconnect_wait_interval });
         };
 
-        for (;;) {
-            if (!util::get_running()) [[unlikely]]
-                break;
-
-            if (token.stop_requested()) [[unlikely]]
-                break;
-
+        while (util::get_running() && !token.stop_requested()) {
             if (!interface->connected()) {
                 reconnect();
                 continue;
+            }
+
+            if (config.record_enable) {
+                const auto request = record_request.load(std::memory_order::relaxed);
+                /*^^*/ if (request == +1) {
+                    // 开始录制
+                    if (!recorder.recording()) {
+                        auto result = recorder.start();
+                        if (!result.has_value()) {
+                            log.error("无法开启录制，报错如下: {}", result.error());
+                        } else {
+                            log.info("成功开启录制");
+                        }
+                    }
+                } else if (request == -1) {
+                    // 停止录制
+                    recorder.stop();
+                    log.info("{}", recorder.status());
+                }
+                record_request.store(0, std::memory_order::relaxed);
             }
 
             if (auto result = interface->wait_image()) {

--- a/src/utility/image/recorder.cpp
+++ b/src/utility/image/recorder.cpp
@@ -4,7 +4,6 @@
 #include <filesystem>
 #include <format>
 #include <memory>
-#include <print>
 #include <string>
 #include <utility>
 
@@ -32,11 +31,12 @@ struct VideoRecorder::Impl {
 
         explicit Session(const std::filesystem::path& dir) {
             // 创建一个人类可读的录制文件名称并将其打开
-            const auto now       = std::chrono::system_clock::now();
+            const auto now =
+                std::chrono::floor<std::chrono::seconds>(std::chrono::system_clock::now());
             const auto our_zone  = std::chrono::locate_zone("Asia/Shanghai");
             const auto zone_time = std::chrono::zoned_time { our_zone, now };
 
-            const auto filename  = std::format("autoaim-{:%Y%m%d_%H%M%S}.avi", zone_time);
+            const auto filename  = std::format("autoaim_{:%Y-%m-%d_%H-%M-%S}.avi", zone_time);
             const auto file_path = dir / filename;
 
             path = file_path;
@@ -85,7 +85,10 @@ struct VideoRecorder::Impl {
 
         auto filename() const { return path.string(); }
 
-        auto duration() const { return std::chrono::steady_clock::now() - opened_timestamp; }
+        auto duration() const {
+            return std::chrono::duration_cast<std::chrono::seconds>(
+                std::chrono::steady_clock::now() - opened_timestamp);
+        }
 
         auto set_remove_later() { remove_later = true; }
 
@@ -96,10 +99,15 @@ struct VideoRecorder::Impl {
     Config config;
     std::filesystem::path selected_directory { };
 
+    std::optional<std::string> stop_reason = std::nullopt;
+
     auto stop(bool save = true) {
         if (session && !save) {
             session->set_remove_later();
         }
+        if (session && !stop_reason)
+            stop_reason = std::format(
+                "录制已由用户停止，文件保存至 {}({})", session->filename(), session->duration());
         session = nullptr;
     }
 
@@ -108,15 +116,18 @@ struct VideoRecorder::Impl {
             return;
         }
         // 时长过长，则自动停止录制，保存至本地
-        if (session->duration() > config.max_duration) {
+        if (session->duration() >= config.max_duration) {
+            stop_reason = std::format("录制时长超过限制({})，已自动停止，文件保存至 {}",
+                config.max_duration, session->filename());
             stop(true);
-            std::println("到点了，哥");
             return;
         }
         session->append(mat);
     }
 
     auto start() -> std::expected<void, std::string> {
+        stop_reason.reset();
+
         { // 从配置中选择第一个有效的目录
             const auto& directories = config.directories;
             for (const auto& dir : directories) {
@@ -163,6 +174,15 @@ struct VideoRecorder::Impl {
 
         return { };
     }
+
+    auto status() const -> std::string {
+        if (stop_reason) {
+            return *stop_reason;
+        }
+        return session != nullptr
+            ? std::format("录制中({})，当前文件为 {}", session->duration(), session->filename())
+            : std::format("未开始录制");
+    }
 };
 
 auto VideoRecorder::update_config(Config config) -> void { pimpl->config = std::move(config); }
@@ -181,6 +201,8 @@ auto VideoRecorder::filename() const -> std::optional<std::string> {
     }
     return pimpl->session->filename();
 }
+
+auto VideoRecorder::status() const -> std::string { return pimpl->status(); }
 
 VideoRecorder::VideoRecorder() noexcept
     : pimpl { std::make_unique<Impl>() } { }

--- a/src/utility/image/recorder.hpp
+++ b/src/utility/image/recorder.hpp
@@ -33,6 +33,8 @@ public:
 
     auto recording() const -> bool;
     auto filename() const -> std::optional<std::string>;
+
+    auto status() const -> std::string;
 };
 
 }

--- a/src/utility/service.hpp
+++ b/src/utility/service.hpp
@@ -1,0 +1,127 @@
+#pragma once
+#include "utility/duck_type.hpp"
+#include "utility/string.hpp"
+
+#include <cerrno>
+#include <filesystem>
+#include <format>
+#include <fstream>
+#include <stdexcept>
+
+#include <fcntl.h>
+#include <poll.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+namespace rmcs::util {
+
+namespace details {
+    struct action_checker {
+        template <typename T>
+        struct result {
+            static constexpr bool v = requires(T t) { t.spin_once(); };
+        };
+    };
+}
+
+template <StaticString Name, typename Callback>
+    requires std::invocable<Callback, std::string_view>
+struct Action {
+    static constexpr auto kNameView = std::string_view { Named<Name>::kView };
+
+    Callback callback;
+    int fd = -1;
+    char buf[256];
+
+    explicit Action(Named<Name>, Callback&& callback)
+        : callback { std::forward<Callback>(callback) } { }
+
+    ~Action() {
+        if (fd >= 0) ::close(fd);
+    }
+
+    auto open(std::string_view prefix) -> void {
+        auto path = std::format("{}{}", prefix, kNameView);
+
+        if (::mkfifo(path.c_str(), 0666)) {
+            if (errno != EEXIST) {
+                throw std::runtime_error { std::format("管道无法打开: {}", path) };
+            }
+        }
+
+        fd = ::open(path.c_str(), O_RDONLY | O_NONBLOCK);
+    }
+
+    auto spin_once() -> void {
+        if (fd < 0) return;
+
+        auto pfd = pollfd { fd, POLLIN, 0 };
+        if (::poll(&pfd, 1, 0) > 0) {
+            auto n = ::read(fd, buf, sizeof(buf));
+            if (n > 0) {
+                callback(std::string_view { buf, static_cast<std::size_t>(n) });
+            }
+        }
+    }
+};
+
+template <StaticString Name, typename... Actions>
+class Service {
+    static constexpr auto kNameView = std::string_view { Named<Name>::kView };
+
+public:
+    explicit Service(Named<Name>, Actions&&... context)
+        : actions { details::action_checker { }, std::forward<Actions>(context)... } {
+        namespace fs = std::filesystem;
+
+        service_location = std::format("/tmp/autoaim/{}/", kNameView);
+        if (fs::exists(service_location)) {
+            fs::remove_all(service_location);
+        }
+
+        fs::create_directories(service_location);
+
+        // 打开所有 action 的 FIFO
+        actions.foreach ([&](auto& action) { action.open(service_location); });
+
+        // 创建 actions 列表文件（只读）
+        auto actions_path = std::format("{}actions", service_location);
+        auto filestream   = std::ofstream { actions_path };
+        if (!filestream) {
+            throw std::runtime_error { std::format("无法创建 actions 文件: {}", actions_path) };
+        }
+        (write_action_path<Actions>(filestream, service_location), ...);
+        filestream.close();
+
+        // 设置为只读 0444
+        fs::permissions(actions_path,
+            fs::perms::owner_read | fs::perms::group_read | fs::perms::others_read,
+            fs::perm_options::replace);
+    }
+
+    auto spin() -> void {
+        actions.foreach ([](auto& action) { action.spin_once(); });
+    }
+
+private:
+    /// @NOTE: 这里的析构顺序，必须保证 actions > on_exit > location
+    std::string service_location { };
+    struct OnExit {
+        std::string_view to_remove;
+        ~OnExit() {
+            namespace fs = std::filesystem;
+            if (fs::exists(to_remove)) {
+                fs::remove_all(to_remove);
+            }
+        }
+    } on_exit { service_location };
+
+    duck_array<Actions...> actions;
+
+    template <typename Action>
+    auto write_action_path(std::ofstream& file, std::string_view prefix) -> void {
+        file << prefix << Action::kNameView << "\n";
+    }
+};
+
+} // namespace rmcs::util

--- a/src/utility/string.hpp
+++ b/src/utility/string.hpp
@@ -35,4 +35,10 @@ struct StaticString {
 template <std::size_t N>
 StaticString(const char (&)[N]) -> StaticString<N>;
 
+template <StaticString String>
+struct Named {
+    static constexpr auto kView = String.view();
+    static constexpr auto kData = String.data;
+};
+
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# 视频录制功能集成

## 概述
本PR为自瞄系统添加了在自瞄运行期间录制视频的功能，通过新增配置项、集成视频录制器、以及建立进程间通信服务框架来实现。

## 主要变更

### 配置管理 (config/config.yaml)
新增录制相关配置项：
- `record_enable`: 录制开关（默认关闭）
- `saving_pathes`: 多个视频保存路径列表（支持 `/home/root/autoaim/`、`/home/ubuntu/autoaim/`、`/tmp/autoaim/`）
- `max_duration_seconds`: 单个视频最大录制时长（60秒）
- `record_fps`: 录制帧率（24 fps）
- `max_videos_size_gb`: 最大视频文件容量限制（50 GB）

### 图像采集器核心改动 (src/kernel/capturer.cpp)
- 将录制配置序列化到Capturer的Config结构体中
- 集成VideoRecorder成员用于视频编码与保存
- 新增后台Service线程，通过FIFO命名管道接收 `cap:record` 指令，支持启动/停止录制的原子信号流转
- 主循环中每帧调用 `recorder.tick()` 处理录制逻辑
- 根据原子变量 `record_request` 的状态（+1/-1）驱动 `recorder.start()` 和 `recorder.stop()` 操作

### 进程间通信框架 (src/utility/service.hpp)
新增通用的FIFO基础Service框架：
- `Action<Name, Callback>`: 为每个命名动作创建/管理命名管道，支持非阻塞轮询读取
- `Service<Name, Actions...>`: 统一管理多个动作，在 `/tmp/autoaim/{name}/` 目录下维护FIFO文件列表，提供 `spin()` 轮询驱动接口

### 字符串工具 (src/utility/string.hpp)
新增 `Named<StaticString>` 模板结构体，在编译期将静态字符串的视图与数组指针导出为常量，用于配合Service框架进行类型安全的动作名称管理。

### 视频录制器增强 (src/utility/image/recorder.cpp/hpp)
- 更新文件名生成格式：`autoaim_{:%Y-%m-%d_%H-%M-%S}.avi`
- `Session::duration()` 改为返回截断到秒级的 `std::chrono::seconds`
- 新增 `stop_reason` 成员用于记录录制停止的原因（超时/手动停止等）
- 新增 `status() const -> std::string` 公开方法，返回当前录制状态：未开始/录制中（含时长）/已停止（含停止原因）

## 技术特点
- 通过原子操作与后台Service线程实现线程安全的录制控制
- 基于FIFO的轻量级IPC机制，无需重型中间件
- 灵活的多路径保存策略，适应不同的部署场景
- 增强的状态报告能力，便于监测和调试

## 代码体量
- 新增文件: 2个 (service.hpp新增，recorder改动)
- 配置变更: +7行
- Capturer核心: +111/-22行
- 录制器: +28/-6行
- 工具类: +6行 (string.hpp) + 127行 (service.hpp)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->