### PR TITLE
wip: add dynamic yaw limits to auto aim and remove unused package fro…

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ ros2 launch rmcs_bringup rmcs.launch.py robot:=mock-autoaim
 |----------|------|------|
 | `/auto_aim/camera_transform` | `Eigen::Isometry3d` | 相机在 OdomImu 坐标系下的位姿 |
 | `/auto_aim/barrel_direction` | `Eigen::Vector3d` | 枪口在 OdomImu 坐标系下的方向 |
+| `/auto_aim/yaw_velocity` | `double` | 云台 yaw 角速度，单位 rad/s，用于估计极限射击窗口 |
 | `/referee/id` | `rmcs_msgs::RobotId` | 机器人 ID，用于判断敌方颜色 |
 
 通过类似下面的方式获取需要的变换：

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -96,8 +96,6 @@ fire_control:
   offset_pitch: +0.0 # degree
 
   attack_window: [60.0, 60.0] # degree [left, right]
-  max_acc: 15000 # deg/s²
-  max_vel: 720 # deg/s
 
   is_lazy_gimbal: false
   require_stable_command: true

--- a/src/component.cpp
+++ b/src/component.cpp
@@ -1,5 +1,7 @@
 #include "kernel/auto_aim.hpp"
 
+#include <algorithm>
+
 #include <eigen3/Eigen/Geometry>
 #include <rmcs_executor/component.hpp>
 #include <rmcs_msgs/robot_id.hpp>
@@ -15,6 +17,7 @@ private:
     InputInterface<Eigen::Isometry3d> camera_transform;
     InputInterface<Eigen::Vector3d> barrel_direction;
     InputInterface<rmcs_msgs::RobotId> robot_id;
+    InputInterface<double> yaw_velocity;
 
     OutputInterface<bool> should_control;
     OutputInterface<bool> should_shoot;
@@ -25,12 +28,16 @@ private:
     OutputInterface<double> yaw_acc;
     OutputInterface<double> pitch_acc;
 
-    std::chrono::steady_clock::time_point last_command_timestamp;
+    Timestamp last_yaw_vel_timestamp;
+    double last_yaw_velocity = kNaN;
+
+    Timestamp last_command_timestamp;
 
 public:
     AutoAimComponent() noexcept {
         register_input("/auto_aim/camera_transform", camera_transform, false);
         register_input("/auto_aim/barrel_direction", barrel_direction, false);
+        register_input("/auto_aim/yaw_velocity", yaw_velocity, false);
         register_input("/referee/id", robot_id, false);
 
         register_output("/auto_aim/should_control", should_control, false);
@@ -57,13 +64,31 @@ public:
     }
 
     auto update() -> void override {
-        auto_aim.with_context([this](AutoAim::Context& ctx) {
-            auto frame = AutoAim::Context::TransformFrame {};
+        auto max_yaw_vel = double { 10.0 };
+        auto max_yaw_acc = double { 200.0 };
+        if (yaw_velocity.ready() && std::isfinite(*yaw_velocity)) {
+            const auto now      = Clock::now();
+            const auto velocity = *yaw_velocity;
+
+            max_yaw_vel = std::max(max_yaw_vel, std::abs(velocity));
+            if (std::isfinite(last_yaw_velocity)) {
+                const auto dt = std::chrono::duration<double>(now - last_yaw_vel_timestamp).count();
+                if (dt > 1e-6) {
+                    max_yaw_acc =
+                        std::max(max_yaw_acc, std::abs((velocity - last_yaw_velocity) / dt));
+                }
+            }
+            last_yaw_vel_timestamp = now;
+            last_yaw_velocity      = velocity;
+        }
+
+        auto_aim.with_context([this, max_yaw_vel, max_yaw_acc](AutoAim::Context& ctx) {
+            auto frame      = AutoAim::Context::TransformFrame { };
             frame.timestamp = Clock::now();
 
             const auto& dir = *barrel_direction;
-            frame.yaw   = std::atan2(dir.y(), dir.x());
-            frame.pitch = std::atan2(-dir.z(), std::hypot(dir.x(), dir.y()));
+            frame.yaw       = std::atan2(dir.y(), dir.x());
+            frame.pitch     = std::atan2(-dir.z(), std::hypot(dir.x(), dir.y()));
 
             const auto& iso             = *camera_transform;
             frame.transform.translation = Translation { iso.translation() };
@@ -73,6 +98,9 @@ public:
             if (ctx.transforms.size() > 100) {
                 ctx.transforms.pop_front();
             }
+
+            ctx.max_yaw_vel = std::max(max_yaw_vel, ctx.max_yaw_vel);
+            ctx.max_yaw_acc = std::max(max_yaw_acc, ctx.max_yaw_acc);
 
             ctx.id = *robot_id;
         });

--- a/src/kernel/auto_aim.cpp
+++ b/src/kernel/auto_aim.cpp
@@ -43,17 +43,21 @@ struct AutoAim::Impl {
     FramerateCounter counter;
 
     auto run(const std::stop_token& stop) -> void {
-
         while (util::get_running() && !stop.stop_requested()) {
+            using namespace rmcs_msgs;
+
             node.spin_once();
 
             auto image = cap.fetch_image();
             if (!image) continue;
 
+            auto max_yaw_vel = 10.0;
+            auto max_yaw_acc = 200.0;
+
             auto iso   = Transform::kIdentity();
             auto yaw   = 0.0;
             auto pitch = 0.0;
-            auto id    = rmcs_msgs::RobotId { };
+            auto id    = RobotId { RobotId::UNKNOWN };
             {
                 using namespace std::chrono_literals;
 
@@ -61,6 +65,9 @@ struct AutoAim::Impl {
                 auto& context = self.current_context;
 
                 id = context.id;
+
+                max_yaw_vel = context.max_yaw_vel;
+                max_yaw_acc = context.max_yaw_acc;
 
                 const auto time = image->timestamp - 8ms;
                 const auto best = std::ranges::min_element(
@@ -78,7 +85,8 @@ struct AutoAim::Impl {
             visual.publish(yaw, "yaw");
 
             if (counter.tick()) {
-                node.info("Autoaim Framerate: {}", counter.fps());
+                node.info("fps: {:03} mya: {:03.1f} myv: {:02.2f}", counter.fps(), max_yaw_acc,
+                    max_yaw_vel);
             }
 
             [[maybe_unused]] auto streamer = std::experimental::scope_exit { [&] {
@@ -170,8 +178,13 @@ struct AutoAim::Impl {
             /// 3. 弹道解算
             auto cmd = Command::kInvalid();
             if (trackable) {
-                fire_v2->update(image->timestamp, yaw, pitch);
-
+                fire_v2->update({
+                    .timestamp   = image->timestamp,
+                    .yaw         = yaw,
+                    .pitch       = pitch,
+                    .max_yaw_vel = max_yaw_vel,
+                    .max_yaw_acc = max_yaw_acc,
+                });
                 if (auto aimed = fire_v2->aim(*trackable)) {
                     cmd.should_track = true;
                     cmd.should_shoot = aimed->shoot;

--- a/src/kernel/auto_aim.hpp
+++ b/src/kernel/auto_aim.hpp
@@ -20,8 +20,8 @@ public:
     struct Command {
         TimePoint timestamp { };
 
-        bool should_track { false };
-        bool should_shoot = { false };
+        bool should_track = false;
+        bool should_shoot = false;
 
         double yaw { kNaN };
         double pitch { kNaN };
@@ -51,6 +51,9 @@ public:
             double pitch = kNaN;
         };
         std::deque<TransformFrame> transforms;
+
+        double max_yaw_vel = 10.0;
+        double max_yaw_acc = 200.0;
 
         DeviceIds invincible = DeviceIds::None();
 

--- a/src/kernel/fire_control.cpp
+++ b/src/kernel/fire_control.cpp
@@ -26,9 +26,6 @@ struct FireControllerV2::Impl {
 
         std::array<double, 2> attack_window { 20.0, 20.0 };
 
-        double max_vel { 0.0 };
-        double max_acc { 0.0 };
-
         double yaw_tolerance { 0.07 };
         double pitch_tolerance { 0.04 };
         bool require_stable_command { true };
@@ -41,8 +38,6 @@ struct FireControllerV2::Impl {
             &Config::offset_yaw, "offset_yaw",
             &Config::offset_pitch, "offset_pitch",
             &Config::attack_window, "attack_window",
-            &Config::max_vel, "max_vel",
-            &Config::max_acc, "max_acc",
             &Config::yaw_tolerance, "yaw_tolerance",
             &Config::pitch_tolerance, "pitch_tolerance",
             &Config::require_stable_command, "require_stable_command",
@@ -53,9 +48,7 @@ struct FireControllerV2::Impl {
 
     std::unique_ptr<ShootEvaluator> shoot_evaluator;
 
-    double cached_yaw   = kNaN;
-    double cached_pitch = kNaN;
-    Timestamp cached_stamp;
+    State state;
 
     std::int8_t last_armor_idx = -1;
 
@@ -107,8 +100,6 @@ struct FireControllerV2::Impl {
         config.offset_pitch     = util::deg2rad(config.offset_pitch);
         config.attack_window[0] = util::deg2rad(config.attack_window[0]);
         config.attack_window[1] = util::deg2rad(config.attack_window[1]);
-        config.max_vel          = util::deg2rad(config.max_vel);
-        config.max_acc          = util::deg2rad(config.max_acc);
 
         shoot_evaluator = std::make_unique<ShootEvaluator>(ShootEvaluator::Config {
             .yaw_tolerance          = config.yaw_tolerance,
@@ -166,7 +157,7 @@ struct FireControllerV2::Impl {
     }
 
     auto get_attack_window(const Trackable& trackable) const -> std::tuple<double, double> {
-        if (config.max_vel <= 0.0 || config.max_acc <= 0.0) {
+        if (state.max_yaw_vel <= 0.0 || state.max_yaw_acc <= 0.0) {
             return { config.attack_window[0], config.attack_window[1] };
         }
 
@@ -176,9 +167,9 @@ struct FireControllerV2::Impl {
         }
 
         // 正弦拟合区间
-        const auto vel_limit = config.max_vel * cycle_time / (2.0 * std::numbers::pi);
-        const auto acc_limit =
-            config.max_acc * cycle_time * cycle_time / (4.0 * std::numbers::pi * std::numbers::pi);
+        const auto vel_limit = state.max_yaw_vel * cycle_time / (2.0 * std::numbers::pi);
+        const auto acc_limit = state.max_yaw_acc * cycle_time * cycle_time
+            / (4.0 * std::numbers::pi * std::numbers::pi);
         const auto min_limit = std::min(vel_limit, acc_limit);
 
         return {
@@ -195,7 +186,7 @@ struct FireControllerV2::Impl {
 
         const auto fly_time  = distance / config.bullet_speed;
         const auto increment = config.shoot_delay
-            + std::chrono::duration<double>(cached_stamp - trackable.get_timestamp()).count();
+            + std::chrono::duration<double>(state.timestamp - trackable.get_timestamp()).count();
 
         auto selected = std::int8_t { -1 };
         auto pre_aim  = false;
@@ -256,7 +247,7 @@ struct FireControllerV2::Impl {
                     .center = center,
                     .armor  = attack,
                 },
-                cached_yaw, cached_pitch);
+                state.yaw, state.pitch);
 
             return Aimed {
                 .yaw     = yaw,
@@ -276,11 +267,7 @@ FireControllerV2::FireControllerV2(const YAML::Node& yaml)
 
 FireControllerV2::~FireControllerV2() noexcept = default;
 
-auto FireControllerV2::update(Timestamp timestamp, double yaw, double pitch) -> void {
-    pimpl->cached_stamp = timestamp;
-    pimpl->cached_yaw   = yaw;
-    pimpl->cached_pitch = pitch;
-}
+auto FireControllerV2::update(State state) -> void { pimpl->state = state; }
 
 auto FireControllerV2::aim(const Trackable& trackable) -> std::optional<Aimed> {
     return pimpl->aim(trackable);

--- a/src/kernel/fire_control.hpp
+++ b/src/kernel/fire_control.hpp
@@ -12,6 +12,16 @@ class FireControllerV2 {
     RMCS_PIMPL_DEFINITION(FireControllerV2)
 
 public:
+    struct State {
+        Timestamp timestamp = { };
+
+        double yaw   = 0.;
+        double pitch = 0.;
+
+        double max_yaw_vel = 10.0;
+        double max_yaw_acc = 200.0;
+    };
+
     struct Aimed {
         double yaw   = 0;
         double pitch = 0;
@@ -25,7 +35,7 @@ public:
 
     explicit FireControllerV2(const YAML::Node&);
 
-    auto update(Timestamp timestamp, double yaw, double pitch) -> void;
+    auto update(State state) -> void;
 
     auto aim(const Trackable&) -> std::optional<Aimed>;
 };

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,21 +7,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(RMCS_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/..")
 set(RMCS_SRC_DIR "${RMCS_SOURCE_DIR}/src")
 
-include(FetchContent)
-
-if(NOT TARGET tinympcstatic)
-    FetchContent_Declare(
-        tinympc
-        GIT_REPOSITORY https://github.com/Alliance-Algorithm/TinyMPC.git
-        GIT_TAG main
-        SOURCE_SUBDIR src/tinympc
-    )
-    FetchContent_MakeAvailable(tinympc)
-    if(TARGET tinympcstatic AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-        target_compile_options(tinympcstatic PRIVATE -w)
-    endif()
-endif()
-
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_gtest REQUIRED)
 find_package(rclcpp REQUIRED)


### PR DESCRIPTION
…m cmake

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

本次修改为自瞄链路加入了动态 yaw 限制，并同步调整了火控接口与配置：

- 新增 `/auto_aim/yaw_velocity` 输入，`AutoAimComponent` 会根据 yaw 角速度估算并传递 `max_yaw_vel`、`max_yaw_acc`。
- `AutoAim::Context` 增加 yaw 相关动态约束字段，主循环与弹道/开火控制流程改为使用这些运行时限制。
- `FireControllerV2` 重构为通过 `State` 结构传入时间、姿态和动态约束，`update` 接口随之调整。
- 配置与测试构建中移除了不再使用的 `max_acc`、`max_vel` 以及 TinyMPC 相关 CMake 拉取逻辑。
- README 补充了新的自瞄输入说明及极限射击窗口估计相关内容。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->