### PR TITLE
feat: add play control button for local video playing

### DIFF
--- a/src/module/capturer/local_video.cpp
+++ b/src/module/capturer/local_video.cpp
@@ -1,80 +1,32 @@
 #include "local_video.hpp"
+#include "utility/service.hpp"
+#include "utility/singleton/running.hpp"
 
+#include <atomic>
 #include <filesystem>
+#include <mutex>
 #include <optional>
-#include <sys/select.h>
-#include <termios.h>
 #include <thread>
-#include <unistd.h>
 
 #include <opencv2/videoio.hpp>
 
 using namespace rmcs::cap;
 
 struct LocalVideo::Impl {
-    struct TerminalRawMode {
-        bool enabled { false };
-        ::termios old { };
-
-        auto enable() noexcept -> void {
-            if (!::isatty(STDIN_FILENO)) {
-                return;
-            }
-            if (::tcgetattr(STDIN_FILENO, &old) != 0) {
-                return;
-            }
-
-            auto raw = old;
-            raw.c_lflag &= static_cast<unsigned int>(~(ICANON | ECHO));
-            raw.c_cc[VMIN]  = 0;
-            raw.c_cc[VTIME] = 0;
-            enabled         = (::tcsetattr(STDIN_FILENO, TCSANOW, &raw) == 0);
-        }
-
-        auto disable() noexcept -> void {
-            if (enabled) {
-                ::tcsetattr(STDIN_FILENO, TCSANOW, &old);
-                enabled = false;
-            }
-        }
-
-        ~TerminalRawMode() noexcept { disable(); }
-
-        static auto poll_key(std::chrono::milliseconds timeout) noexcept -> std::optional<char> {
-            auto readfds = fd_set { };
-            FD_ZERO(&readfds);
-            FD_SET(STDIN_FILENO, &readfds);
-
-            auto tv = timeval {
-                .tv_sec  = static_cast<long>(timeout.count() / 1'000),
-                .tv_usec = static_cast<long>((timeout.count() % 1'000) * 1'000),
-            };
-
-            if (::select(STDIN_FILENO + 1, &readfds, nullptr, nullptr, &tv) <= 0) {
-                return std::nullopt;
-            }
-
-            char key = 0;
-            if (::read(STDIN_FILENO, &key, 1) != 1) {
-                return std::nullopt;
-            }
-
-            return key;
-        }
-    };
-
-    Config config;
-
     using Clock     = std::chrono::steady_clock;
     using TimePoint = std::chrono::steady_clock::time_point;
 
+    Config config;
+
     std::optional<cv::VideoCapture> capturer;
+    std::mutex image_mutex;
     bool playing { true };
-    TerminalRawMode terminal_raw_mode;
     std::optional<Image> latest_image;
 
     std::chrono::nanoseconds interval_duration { 0 };
     TimePoint last_read_time { Clock::now() };
+
+    std::jthread service_thread;
 
     auto set_framerate_interval(double hz) noexcept -> void {
         if (hz > 0) {
@@ -84,6 +36,73 @@ struct LocalVideo::Impl {
             interval_duration = std::chrono::nanoseconds { 0 };
         }
     };
+
+    auto step_frame_locked(int offset) -> void {
+        if (!capturer.has_value()) return;
+
+        auto frame = cv::Mat { };
+        if (offset < 0) {
+            const auto pos = static_cast<int>(capturer->get(cv::CAP_PROP_POS_FRAMES));
+            if (pos < 2) return;
+            capturer->set(cv::CAP_PROP_POS_FRAMES, pos - 2);
+            if (!capturer->read(frame) || frame.empty()) return;
+        } else {
+            if (!capturer->read(frame) || frame.empty()) return;
+        }
+
+        latest_image = Image {
+            .mat       = std::move(frame),
+            .timestamp = Clock::now(),
+        };
+    }
+
+    auto start_service() -> void {
+        service_thread = std::jthread { [this](const std::stop_token& token) {
+            using namespace util;
+            auto dirty = std::atomic<bool> { true };
+
+            auto service = Service {
+                Named<"local_video"> { },
+                Action { Named<"play_pause">(),
+                    [this, &dirty](std::string_view) {
+                        std::lock_guard guard { image_mutex };
+                        playing = !playing;
+                        dirty.store(true);
+                    } },
+                Action { Named<"step_forward">(),
+                    [this, &dirty](std::string_view) {
+                        std::lock_guard guard { image_mutex };
+                        if (playing) return;
+                        step_frame_locked(+1);
+                        dirty.store(true);
+                    } },
+                Action { Named<"step_backward">(),
+                    [this, &dirty](std::string_view) {
+                        std::lock_guard guard { image_mutex };
+                        if (playing) return;
+                        step_frame_locked(-1);
+                        dirty.store(true);
+                    } },
+            };
+
+            while (!token.stop_requested() && get_running()) {
+                service.spin();
+                if (dirty.exchange(false)) {
+                    std::lock_guard guard { image_mutex };
+                    service.update_later("playing", playing ? "1" : "0");
+                    service.update_later("source", "local_video");
+                }
+                std::this_thread::sleep_for(std::chrono::milliseconds { 100 });
+            }
+        } };
+    }
+
+    auto stop_service() noexcept -> void {
+        service_thread.request_stop();
+        if (service_thread.joinable()) {
+            service_thread.join();
+        }
+    }
 
     auto configure(Config const& _config) -> std::expected<void, std::string> {
         if (_config.location.empty() || !std::filesystem::exists(_config.location)) {
@@ -100,8 +119,8 @@ struct LocalVideo::Impl {
             return std::unexpected { "Failed to construct VideoCapture due to an unknown error." };
         }
 
-        double source_fps = capturer->get(cv::CAP_PROP_FPS);
-        double target_fps = source_fps > 0 ? source_fps : 30.0;
+        auto source_fps = capturer->get(cv::CAP_PROP_FPS);
+        auto target_fps = source_fps > 0 ? source_fps : 30.0;
 
         if (config.frame_rate > 0) {
             target_fps = config.frame_rate;
@@ -109,10 +128,14 @@ struct LocalVideo::Impl {
 
         set_framerate_interval(target_fps);
 
-        playing      = true;
-        latest_image = std::nullopt;
-        terminal_raw_mode.enable();
+        {
+            std::lock_guard guard { image_mutex };
+            playing      = true;
+            latest_image = std::nullopt;
+        }
         last_read_time = Clock::now();
+
+        start_service();
 
         return { };
     }
@@ -122,11 +145,15 @@ struct LocalVideo::Impl {
     auto connected() const noexcept -> bool { return capturer.has_value() && capturer->isOpened(); }
 
     auto disconnect() noexcept -> void {
-        if (capturer.has_value()) {
-            capturer.reset();
+        stop_service();
+
+        {
+            std::lock_guard guard { image_mutex };
+            if (capturer.has_value()) {
+                capturer.reset();
+            }
+            latest_image = std::nullopt;
         }
-        latest_image = std::nullopt;
-        terminal_raw_mode.disable();
         interval_duration = std::chrono::nanoseconds { 0 };
     }
 
@@ -135,18 +162,9 @@ struct LocalVideo::Impl {
             return std::unexpected { "Video stream is not opened." };
         }
 
-        using namespace std::chrono_literals;
-
-        if (const auto key = TerminalRawMode::poll_key(0ms); key == ' ') {
-            playing = !playing;
-            if (playing) {
-                last_read_time = Clock::now();
-            }
-        }
-
         const auto time_before_read        = Clock::now();
         const auto next_read_time_expected = last_read_time + interval_duration;
-        auto wait_duration                 = next_read_time_expected - time_before_read;
+        const auto wait_duration           = next_read_time_expected - time_before_read;
 
         if (wait_duration.count() > 0) {
             std::this_thread::sleep_for(wait_duration);
@@ -155,11 +173,14 @@ struct LocalVideo::Impl {
             last_read_time = config.allow_skipping ? Clock::now() : next_read_time_expected;
         }
 
-        if (!playing && latest_image) {
-            auto image       = std::make_unique<Image>();
-            image->mat       = latest_image->mat.clone();
-            image->timestamp = latest_image->timestamp;
-            return image;
+        {
+            std::lock_guard guard { image_mutex };
+            if (!playing && latest_image) {
+                auto image       = std::make_unique<Image>();
+                image->mat       = latest_image->mat.clone();
+                image->timestamp = latest_image->timestamp;
+                return image;
+            }
         }
 
         auto frame = cv::Mat { };
@@ -169,9 +190,7 @@ struct LocalVideo::Impl {
                 if (capturer->set(cv::CAP_PROP_POS_FRAMES, 0) && capturer->read(frame)) {
                     last_read_time = Clock::now();
                 } else {
-                    return std::unexpected {
-                        "End of file reached and failed to loop/reset.",
-                    };
+                    return std::unexpected { "End of file reached and failed to loop/reset." };
                 }
             } else {
                 return std::unexpected { "End of file reached." };
@@ -181,12 +200,17 @@ struct LocalVideo::Impl {
         if (frame.empty()) {
             return std::unexpected { "Read frame is empty, possibly due to IO error." };
         }
+
         image->mat       = std::move(frame);
         image->timestamp = last_read_time;
-        latest_image     = Image {
-            .mat       = image->mat.clone(),
-            .timestamp = last_read_time,
-        };
+
+        {
+            std::lock_guard guard { image_mutex };
+            latest_image = {
+                .mat       = image->mat.clone(),
+                .timestamp = last_read_time,
+            };
+        }
 
         return image;
     };
@@ -195,6 +219,7 @@ struct LocalVideo::Impl {
 auto LocalVideo::configure(Config const& config) -> std::expected<void, std::string> {
     return pimpl->configure(config);
 }
+
 auto LocalVideo::wait_image() noexcept -> std::expected<std::unique_ptr<Image>, std::string> {
     return pimpl->wait_image();
 }

--- a/tool/res/playing.html
+++ b/tool/res/playing.html
@@ -219,6 +219,15 @@
             transform: none;
         }
 
+        .playback-row {
+            display: flex;
+            gap: 8px;
+        }
+
+        .playback-row > button {
+            flex: 1;
+        }
+
         @media (prefers-reduced-motion: reduce) {
 
             *,
@@ -311,6 +320,18 @@
                 </div>
             </section>
             <button id="backend-record-button" class="record-button" type="button" disabled>等待录制状态</button>
+
+            <div style="height: 10px; flex: 0 0 auto;" aria-hidden="true"></div>
+
+            <section class="panel-group">
+                <h2>本地视频控制</h2>
+                <p>仅本地视频源可用</p>
+                <div class="playback-row">
+                    <button id="prev-btn" class="capture-button" type="button" disabled>-1</button>
+                    <button id="play-pause-btn" class="capture-button" type="button" disabled>暂停</button>
+                    <button id="next-btn" class="capture-button" type="button" disabled>+1</button>
+                </div>
+            </section>
         </aside>
     </main>
 
@@ -349,6 +370,12 @@
         const recordButtonLabel = document.querySelector('.record-button-label');
         /** @type {HTMLButtonElement} */
         const backendRecordButton = document.getElementById('backend-record-button');
+        /** @type {HTMLButtonElement} */
+        const prevButton = document.getElementById('prev-btn');
+        /** @type {HTMLButtonElement} */
+        const playPauseButton = document.getElementById('play-pause-btn');
+        /** @type {HTMLButtonElement} */
+        const nextButton = document.getElementById('next-btn');
         /** @type {HTMLSpanElement} */
         const backendRecordOnValue = document.getElementById('backend-record-on-value');
         /** @type {HTMLSpanElement} */
@@ -374,6 +401,9 @@
         });
         captureButton.addEventListener('click', captureFrame);
         backendRecordButton.addEventListener('click', toggleBackendRecording);
+        prevButton.addEventListener('click', () => sendPlaybackCommand('/api/step_backward'));
+        playPauseButton.addEventListener('click', () => sendPlaybackCommand('/api/play_pause'));
+        nextButton.addEventListener('click', () => sendPlaybackCommand('/api/step_forward'));
 
         function updateLocalActionButtons() {
             const hasStream = Boolean(currentStream);
@@ -402,6 +432,27 @@
             backendRecordButton.disabled = false;
         }
 
+        /** @type {boolean} */
+        let isLocalVideo = false;
+        /** @type {boolean} */
+        let isPlaying = true;
+
+        function updatePlaybackButtons() {
+            const enabled = isLocalVideo;
+            prevButton.disabled = !enabled || isPlaying;
+            playPauseButton.disabled = !enabled;
+            nextButton.disabled = !enabled || isPlaying;
+            playPauseButton.textContent = isPlaying ? '暂停' : '播放';
+        }
+
+        async function sendPlaybackCommand(url) {
+            try {
+                await fetch(url, { method: 'POST', body: '1' });
+            } catch (error) {
+                console.error('Playback command failed:', error);
+            }
+        }
+
         async function fetchRecordContext() {
             try {
                 const response = await fetch('/api/context', {cache: 'no-store'});
@@ -415,15 +466,20 @@
                 backendRecordOnValue.textContent = backendRecordOn ? '开启' : '关闭';
                 backendStatusValue.textContent = recordContext.recordStatus || '-';
                 backendFilenameValue.textContent = recordContext.filename || '-';
+                isLocalVideo = recordContext.source === 'local_video';
+                isPlaying = Boolean(recordContext.playing);
             } catch (error) {
                 backendRecordOn = null;
                 backendRecordOnValue.textContent = '未知';
                 backendStatusValue.textContent = '状态不可用';
                 backendFilenameValue.textContent = '-';
+                isLocalVideo = false;
+                isPlaying = true;
                 console.error('Failed to fetch record context:', error);
             }
 
             updateBackendRecordButton();
+            updatePlaybackButtons();
         }
 
         async function sendRecordCommand(value) {

--- a/tool/res/start-streamer
+++ b/tool/res/start-streamer
@@ -23,6 +23,10 @@ playerRoute = "/res/playing.html"
 playerFile = "playing.html"
 fifoRecordPath = "/tmp/autoaim/cap/record"
 contextPath = "/tmp/autoaim/cap/context"
+fifoPlayPause = "/tmp/autoaim/local_video/play_pause"
+fifoStepForward = "/tmp/autoaim/local_video/step_forward"
+fifoStepBackward = "/tmp/autoaim/local_video/step_backward"
+contextLocalVideo = "/tmp/autoaim/local_video/context"
 
 
 # ── HTTP Handler ─────────────────────────────────────────────────────────────
@@ -41,9 +45,18 @@ class AutoAimHandler(SimpleHTTPRequestHandler):
             return
         return super().do_GET()
 
+    localVideoRoutes = {
+        "/api/play_pause": fifoPlayPause,
+        "/api/step_forward": fifoStepForward,
+        "/api/step_backward": fifoStepBackward,
+    }
+
     def do_POST(self) -> None:
         if self.path == "/api/record":
             self.handleRecord()
+            return
+        if self.path in self.localVideoRoutes:
+            self.write_to_fifo(self.localVideoRoutes[self.path], "1")
             return
         self.send_error(404, "Not Found")
 
@@ -56,10 +69,13 @@ class AutoAimHandler(SimpleHTTPRequestHandler):
                 400, {"status": "error", "message": "invalid value"})
             return
 
+        self.write_to_fifo(fifoRecordPath, body)
+
+    def write_to_fifo(self, path: str, value: str) -> None:
         fd = None
         try:
-            fd = os.open(fifoRecordPath, os.O_WRONLY | os.O_NONBLOCK)
-            os.write(fd, body.encode())
+            fd = os.open(path, os.O_WRONLY | os.O_NONBLOCK)
+            os.write(fd, value.encode())
             self.jsonResponse(200, {"status": "ok"})
         except OSError as e:
             self.jsonResponse(500, {"status": "error", "message": str(e)})
@@ -80,22 +96,35 @@ class AutoAimHandler(SimpleHTTPRequestHandler):
             "filename": "not started",
             "recordStatus": "context not found",
             "recordOn": False,
+            "source": "",
+            "playing": True,
         }
 
-        with open(contextPath, "r") as f:
-            for line in f:
-                name, separator, content = line.partition(":")
-                if not separator:
-                    continue
-                value = content.strip()
-                if name == "filename":
-                    context["filename"] = value
-                elif name == "status":
-                    context["recordStatus"] = value
-                elif name == "record_on":
-                    context["recordOn"] = value in ("1", "true")
+        self.readFileToContext(contextPath, context)
+        self.readFileToContext(contextLocalVideo, context)
 
         return context
+
+    def readFileToContext(self, path: str, context: dict[str, object]) -> None:
+        try:
+            with open(path, "r") as f:
+                for line in f:
+                    name, separator, content = line.partition(":")
+                    if not separator:
+                        continue
+                    value = content.strip()
+                    if name == "filename":
+                        context["filename"] = value
+                    elif name == "status":
+                        context["recordStatus"] = value
+                    elif name == "record_on":
+                        context["recordOn"] = value in ("1", "true")
+                    elif name == "playing":
+                        context["playing"] = value == "1"
+                    elif name == "source":
+                        context["source"] = value
+        except OSError:
+            pass
 
     def jsonResponse(self, code: int, data: dict) -> None:
         body = json.dumps(data).encode()
@@ -226,10 +255,7 @@ class StreamServer:
 
     def printStartupInfo(self, host: str) -> None:
         print("AutoAim stream server started.\n")
-        print(f"Player page:\n  http://127.0.0.1:{self.playerPort}/autoaim\n")
-        print(f"Remote page:\n  http://{host}:{self.playerPort}/autoaim\n")
-        print(
-            f"WHEP endpoint:\n  http://127.0.0.1:{self.mediamtxPort}/autoaim/whep\n")
+        print(f"Please access -> http://<ip>:{self.playerPort}/autoaim\n")
         print("Press Ctrl+C to stop.")
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

本次变更为本地视频播放补充了完整的控制链路，并同步更新前后端交互。

主要内容：
- `src/module/capturer/local_video.cpp` 重构本地视频读取与控制逻辑，移除终端按键轮询方式，改为通过后台服务线程管理播放/暂停与逐帧控制；新增帧步进读取、`latest_image` 同步缓存及相关并发保护。
- `tool/res/start-streamer` 扩展服务端接口，新增 `/api/play_pause`、`/api/step_forward`、`/api/step_backward`，将播放控制请求写入对应 FIFO；同时调整 context 读取逻辑，合并本地视频与录制状态信息。
- `tool/res/playing.html` 增加本地视频控制按钮与交互状态展示，支持上一帧、播放/暂停、下一帧操作，并根据 `local_video` 状态动态启用/禁用按钮。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->